### PR TITLE
Core static functions namespace.

### DIFF
--- a/src/camera.js
+++ b/src/camera.js
@@ -1,6 +1,7 @@
 goog.provide('olcs.Camera');
 
 goog.require('goog.events');
+goog.require('olcs.core');
 
 
 
@@ -230,18 +231,8 @@ olcs.Camera.prototype.getAltitude = function() {
 olcs.Camera.prototype.lookAt = function(position) {
   var ll = this.toLonLat_(position);
 
-  var carto = new Cesium.Cartographic(goog.math.toRadians(ll[0]),
-                                      goog.math.toRadians(ll[1]));
-  if (this.scene_.globe) {
-    var height = this.scene_.globe.getHeight(carto);
-    carto.height = goog.isDef(height) ? height : 0;
-  }
-  var carte = Cesium.Ellipsoid.WGS84.cartographicToCartesian(carto);
-
-  var pos = this.cam_.position;
-  var up = Cesium.Ellipsoid.WGS84.geocentricSurfaceNormal(
-      pos, new Cesium.Cartesian3());
-  this.cam_.lookAt(pos, carte, up);
+  var carto = Cesium.Cartographic.fromDegrees(ll[0], ll[1]);
+  olcs.core.lookAt(this.cam_, carto, this.scene_.globe);
 
   this.updateView();
 };

--- a/src/core.js
+++ b/src/core.js
@@ -1,0 +1,28 @@
+goog.provide('olcs.core');
+
+
+
+/**
+ * Rotate the camera so that its direction goes through the target point.
+ * If a globe is given, the target height is first interpolated from terrain.
+ * @param {!Cesium.Camera} camera
+ * @param {!Cesium.Cartographic} target
+ * @param {Cesium.Globe=} opt_globe
+ * @api
+ */
+olcs.core.lookAt = function(camera, target, opt_globe) {
+  if (goog.isDef(opt_globe)) {
+    var height = opt_globe.getHeight(target);
+    target.height = goog.isDef(height) ? height : 0;
+  }
+
+  var ellipsoid = Cesium.Ellipsoid.WGS84;
+  target = ellipsoid.cartographicToCartesian(target);
+
+  var position = camera.position;
+  var up = new Cesium.Cartesian3();
+  ellipsoid.geocentricSurfaceNormal(position, up);
+
+  camera.lookAt(position, target, up);
+};
+


### PR DESCRIPTION
The olcs.core namespace is intented to contain low level and reusable code.
Examples of such code include:
- mathematic primitives;
- convenience wrappers around Ol3 or Cesium (like the lookAt here);
- synchronization primitives (like in the PR https://github.com/boundlessgeo/ol3-cesium/pull/25).

Then, higher level code will be shorter and easier to read, lot of low level complexity 
being in the core.
