### PR TITLE
Do not render Cesium if ol3cesium is not enabled

### DIFF
--- a/src/ol3cesium.js
+++ b/src/ol3cesium.js
@@ -113,8 +113,10 @@ olcs.OLCesium = function(map, opt_target) {
 
   var tick = goog.bind(function() {
     this.scene_.initializeFrame();
-    this.scene_.render();
-    this.camera_.checkCameraChange();
+    if (this.enabled_) {
+      this.scene_.render();
+      this.camera_.checkCameraChange();
+    }
     Cesium.requestAnimationFrame(tick);
   }, this);
   Cesium.requestAnimationFrame(tick);


### PR DESCRIPTION
This PR partially implements #19 -- it ensures that Cesium Scene is not rendered if not enabled (and thus not visible).

This PR does **not** stop ol3 rendering if the "stacked view" mode is enable (when 2d map is hidden under the Cesium). How to implement this is to be discussed (details in #19).
