### PR TITLE
Vector layer conversion

### DIFF
--- a/examples/vectors.html
+++ b/examples/vectors.html
@@ -10,8 +10,10 @@
   <body>
     <div id="map2d" style="width:600px;height:400px;float:left;"></div>
     <div id="map3d" style="width:600px;height:400px;float:left;position:relative;"></div>
-    <div><input type="button" value="Enable/disable"
+    <div><input type="button" value="Enable/disable Cesium"
       onclick="javascript:ol3d.setEnabled(!ol3d.getEnabled())" /></div>
+    <div><input type="button" value="Enable/disable depth test"
+      onclick="javascript:scene.globe.depthTestAgainstTerrain = !scene.globe.depthTestAgainstTerrain" /></div>
     <script src="../ol3/build/ol.js"></script>
     <script src="../cesium/Build/Cesium/Cesium.js"></script>
     <script src="/@loader"></script>

--- a/examples/vectors.js
+++ b/examples/vectors.js
@@ -1,22 +1,22 @@
 var iconFeature = new ol.Feature({
-    geometry: new ol.geom.Point([700000, 200000]),
-      name: 'Null Island',
-      population: 4000,
-      rainfall: 500
+  geometry: new ol.geom.Point([700000, 200000]),
+  name: 'Null Island',
+  population: 4000,
+  rainfall: 500
 });
 
 var iconStyle = new ol.style.Style({
-    image: new ol.style.Icon(/** @type {olx.style.IconOptions} */ ({
-      anchor: [0.5, 46],
-      anchorXUnits: 'fraction',
-      anchorYUnits: 'pixels',
-      opacity: 0.75,
-      src: 'data/icon.png'
-    })),
-    text: new ol.style.Text({
-      text: 'Icon',
-      font: 'italic'
-    })
+  image: new ol.style.Icon(/** @type {olx.style.IconOptions} */ ({
+    anchor: [0.5, 46],
+    anchorXUnits: 'fraction',
+    anchorYUnits: 'pixels',
+    opacity: 0.75,
+    src: 'data/icon.png'
+  })),
+  text: new ol.style.Text({
+    text: 'Icon',
+    font: 'italic'
+  })
 });
 
 iconFeature.setStyle(iconStyle);
@@ -138,7 +138,22 @@ var vectorSource = new ol.source.GeoJSON(
             'type': 'Feature',
             'geometry': {
               'type': 'LineString',
-              'coordinates': [[4e6, -2e6], [8e6, 2e6]]
+              'coordinates': [
+                [1e5, 1e5, 1],
+                [2e5, 2e5, 100000],
+                [3e5, 3e5, 1000],
+                [4e5, 4e5, 100000],
+                [5e5, 5e5, 100],
+                [6e5, 6e5, 100000],
+                [7e5, 7e5, 1]
+              ]
+            }
+          },
+          {
+            'type': 'Feature',
+            'geometry': {
+              'type': 'LineString',
+              'coordinates': [[4e6, -2e6, 100000], [8e6, 2e6, 200000]]
             }
           },
           {
@@ -222,11 +237,11 @@ var vectorLayer = new ol.layer.Vector({
 
 
 var vectorSource2 = new ol.source.Vector({
-    features: [iconFeature]
+  features: [iconFeature]
 });
 
 var vectorLayer2 = new ol.layer.Vector({
-    source: vectorSource2
+  source: vectorSource2
 });
 
 var dragAndDropInteraction = new ol.interaction.DragAndDrop({
@@ -245,7 +260,10 @@ var map = new ol.Map({
   interactions: ol.interaction.defaults().extend([dragAndDropInteraction]),
   layers: [
     new ol.layer.Tile({
-      source: new ol.source.OSM()
+      source: new ol.source.BingMaps({
+        key: 'Ak-dzM4wZjSqTlzveKz5u0d4IQ4bRzVI309GxmkgSVr1ewS6iPSrOvOKhA-CJlm3',
+        imagerySet: 'Aerial'
+      })
     }),
     vectorLayer,
     vectorLayer2
@@ -283,6 +301,7 @@ var terrainProvider = new Cesium.CesiumTerrainProvider({
   url: '//cesiumjs.org/stk-terrain/tilesets/world/tiles'
 });
 scene.terrainProvider = terrainProvider;
+scene.globe.depthTestAgainstTerrain = true;
 ol3d.setEnabled(true);
 
 setTimeout(function() {
@@ -294,8 +313,8 @@ setTimeout(function() {
 
 var csLabels = new Cesium.LabelCollection();
 csLabels.add({
-    position: Cesium.Cartesian3.fromRadians(20, 20, 0),
-    text: 'Pre-existing primitive'
+  position: Cesium.Cartesian3.fromRadians(20, 20, 0),
+  text: 'Pre-existing primitive'
 });
 scene.primitives.add(csLabels);
 

--- a/src/core.js
+++ b/src/core.js
@@ -530,7 +530,7 @@ goog.require('olcs.core.OLImageryProvider');
         reallyCreateBillboard();
       };
 
-      goog.events.listenOnce(image, 'load', listener, false, this);
+      goog.events.listenOnce(image, 'load', listener);
     } else {
       reallyCreateBillboard();
     }


### PR DESCRIPTION
Core converters to be used by the vector synchronizer. https://github.com/boundlessgeo/ol3-cesium/issues/4 / https://github.com/boundlessgeo/ol3-cesium/issues/11

It handles:
- all shapes;
- fill and stroke colours;
- outline width.

Dashes are not handled in general though some experimental code exists for lines.

It is now ready for merging though some issues remain:
- for each geometry class, exporting the position where the text is placed
  See drawText in src/ol/render/vector.js.
- only the first style of an array is used for Cesium
  Blending styles to a unique plain style would be an idea, see http://en.wikipedia.org/wiki/Alpha_compositing#Alpha_blending

Updated to reflect new state.
Old demo at http://dev.camptocamp.com/files/gberaudo/vectors/examples/vectors.html
