### PR TITLE
Performance: hide ol layers when 2D not visible

### DIFF
--- a/src/ol3cesium.js
+++ b/src/ol3cesium.js
@@ -210,8 +210,11 @@ olcs.OLCesium.prototype.setEnabled = function(opt_enable) {
       }, this);
       interactions.clear();
 
-      this.hiddenRootGroup_ = this.map_.getLayerGroup();
-      this.hiddenRootGroup_.setVisible(false);
+      var rootGroup = this.map_.getLayerGroup();
+      if (rootGroup.getVisible()) {
+        this.hiddenRootGroup_ = rootGroup;
+        this.hiddenRootGroup_.setVisible(false);
+      }
     }
     this.handleResize_();
     this.camera_.readFromView();


### PR DESCRIPTION
Related to https://github.com/boundlessgeo/ol3-cesium/issues/19#issuecomment-55743145.

This optimization hides the root LayerGroup (`ol.Map#getLayerGroup`) via `setVisible(false)` to prevent the underlying layers from being rendered.
The Chrome Dev Tools report that the tiles are not even being requested, so the performance gain should be noticeable (please report).

If the developer changes the root LayerGroup (via `setLayerGroup()`) everything works OK, but the original LayerGroup will still have `visible` set to `false` -- until the ol3cesium is re-enabled.
If the developer tries to hide the root LayerGroup when already hidden by ol3cesium, this setting will be overwritten when re-enabling ol3cesium.

These rare issues could be solved by adding some event listeners, but I don't think it's worth the extra code that would be required. Opinions?
