### PR TITLE
Raster sync performance when source fires change

### DIFF
--- a/Cesium.externs.js
+++ b/Cesium.externs.js
@@ -1455,6 +1455,13 @@ Cesium.ImageryLayerCollection.prototype.get = function(index) {};
 
 /**
  * @param {Cesium.ImageryLayer} layer
+ * @return {number} index
+ */
+Cesium.ImageryLayerCollection.prototype.indexOf = function(layer) {};
+
+
+/**
+ * @param {Cesium.ImageryLayer} layer
  * @param {number=} opt_index
  */
 Cesium.ImageryLayerCollection.prototype.add = function(layer, opt_index) {};

--- a/src/rastersynchronizer.js
+++ b/src/rastersynchronizer.js
@@ -159,8 +159,12 @@ olcs.RasterSynchronizer.prototype.synchronize = function() {
         }, this);
 
         olLayer.on('change', function(e) {
-          // when the source changes, re-add the layers to force update
-          this.synchronize();
+          // when the source changes, re-add the layer to force update
+          var position = this.cesiumLayers_.indexOf(cesiumLayer);
+          if (position >= 0) {
+            this.cesiumLayers_.remove(cesiumLayer, false);
+            this.cesiumLayers_.add(cesiumLayer, position);
+          }
         }, this);
       }
       this.layerMap_[olLayerId] = cesiumLayer;


### PR DESCRIPTION
This PR improves raster synchronization performance when the source fires change event (e.g. `ol.source.TileWMS#updateParams`).
Instead of a full resync, only the changed layer is re-added to Cesium to force the tile update.

Closes #78.
