### PR TITLE
Tentative fix for compiler errors when storing properties.

### DIFF
--- a/Cesium.externs.js
+++ b/Cesium.externs.js
@@ -902,6 +902,14 @@ Cesium.optionsPrimitive;
 Cesium.Primitive = function(opt_opts) {};
 
 /**
+ * Workaround for finding the feature associated to a primitive.
+ * Required since the Primitive lacks a dedicated id property, as shown in:
+ * http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Picking.html&label=Showcases
+ * @type {string|number|undefined}
+ */
+Cesium.Primitive.prototype.olFeatureId;
+
+/**
  * @constructor
  * @extends {Cesium.Primitive}
  */

--- a/src/core.js
+++ b/src/core.js
@@ -802,7 +802,6 @@ goog.require('olcs.core.OLImageryProvider');
     goog.asserts.assert(style instanceof ol.style.Style);
 
     var id = function(primitives) {
-      feature.csPrimitive = primitives;
       primitives.olFeatureId = feature.getId();
       return primitives;
     };
@@ -872,12 +871,16 @@ goog.require('olcs.core.OLImageryProvider');
 
   /**
    * Convert an OpenLayers vector layer to Cesium primitive collection.
+   * For each feature, the associated primitive will be stored in
+   * `featurePrimitiveMap`.
    * @param {!ol.layer.Vector} olLayer
    * @param {!ol.View} olView
+   * @param {!Object.<!ol.Feature, !Cesium.Primitive>} featurePrimitiveMap
    * @return {!Cesium.PrimitiveCollection}
    * @api
    */
-  olcs.core.olVectorLayerToCesium = function(olLayer, olView) {
+  olcs.core.olVectorLayerToCesium = function(olLayer, olView,
+      featurePrimitiveMap) {
     goog.asserts.assert(olLayer instanceof ol.layer.Vector);
 
     var vectorLayer = olLayer;
@@ -903,6 +906,7 @@ goog.require('olcs.core.OLImageryProvider');
         continue;
       }
       var primitives = olcs.core.olFeatureToCesium(feature, layerStyle, proj);
+      featurePrimitiveMap[feature] = primitives;
       allPrimitives.add(primitives);
     }
 


### PR DESCRIPTION
Using a map for storing the primitive associated to a feature.
The Cesium extern gets a new property for Primitive for storing the associated feature id.
