### PR TITLE
Remind the compiler of the type of olLayer

### DIFF
--- a/src/abstractsynchronizer.js
+++ b/src/abstractsynchronizer.js
@@ -188,7 +188,7 @@ olcs.AbstractSynchronizer.prototype.synchronizeSingle = function(olLayer) {
       // only the keys that need to be relistened when collection changes
       var collection, contentKeys = [];
       var listenAddRemove = goog.bind(function() {
-        collection = olLayer.getLayers();
+        collection = /** @type {ol.layer.Group} */ (olLayer).getLayers();
         if (goog.isDef(collection)) {
           var handleContentChange_ = goog.bind(function(e) {
             this.synchronize();


### PR DESCRIPTION
This closure is created in an if-block for ol.layer.Group instances only.

This change fixes a final type check error. Thanks @schmidtk for making me aware of this and pointing out the solution.
