### PR TITLE
Fixed type of Cesium context projection

### DIFF
--- a/src/core/ollayerprimitive.js
+++ b/src/core/ollayerprimitive.js
@@ -4,7 +4,7 @@ goog.provide('olcs.core.OlLayerPrimitive');
 /**
  * Context for feature conversion.
  * @typedef {{
- *  projection: (!ol.proj.ProjectionLike),
+ *  projection: (!(ol.proj.Projection|string)),
  *  primitives: (!Cesium.PrimitiveCollection),
  *  featureToCesiumMap: (Object.<
  *    number,
@@ -20,7 +20,7 @@ olcs.core.OlFeatureToCesiumContext;
 /**
  * Result of the conversion of an OpenLayers layer to Cesium.
  * @constructor
- * @param {!ol.proj.ProjectionLike} layerProjection
+ * @param {!(ol.proj.Projection|string)} layerProjection
  * @extends {Cesium.PrimitiveCollection}
  */
 olcs.core.OlLayerPrimitive = function(layerProjection) {


### PR DESCRIPTION
The type `!ol.proj.ProjectionLike` still allows for `null|undefined`, which is causing compile errors in [olcs.core.olFeatureToCesium](https://github.com/boundlessgeo/ol3-cesium/blob/master/src/core.js#L837). The projection is tested to ensure it isn't null or undefined, so it's safe to declare the type in the context as a projection or string.
