### PR TITLE
Update demo GeoServer location

### DIFF
--- a/examples/epsg-4326.js
+++ b/examples/epsg-4326.js
@@ -6,7 +6,7 @@ var view = new ol.View({
 
 var layer = new ol.layer.Tile({
   source: new ol.source.TileWMS({
-    url: 'http://demo.opengeo.org/geoserver/wms',
+    url: 'http://demo.boundlessgeo.com/geoserver/wms',
     params: {
       'LAYERS': 'ne:NE1_HR_LC_SR_W_DR'
     }
@@ -16,7 +16,7 @@ var overlay = new ol.layer.Tile({
   opacity: 0.7,
   extent: [-124.74, 24.96, -66.96, 49.38],
   source: new ol.source.TileWMS(/** @type {olx.source.TileWMSOptions} */ ({
-    url: 'http://demo.opengeo.org/geoserver/wms',
+    url: 'http://demo.boundlessgeo.com/geoserver/wms',
     params: {'LAYERS': 'topp:states', 'TILED': true},
     serverType: 'geoserver',
     crossOrigin: 'anonymous'

--- a/examples/rastersync.js
+++ b/examples/rastersync.js
@@ -62,7 +62,7 @@ var addStamen = function() {
 };
 
 var tileWMSSource = new ol.source.TileWMS(/** @type {olx.source.TileWMSOptions} */ ({
-      url: 'http://demo.opengeo.org/geoserver/wms',
+      url: 'http://demo.boundlessgeo.com/geoserver/wms',
       params: {'LAYERS': 'topp:states', 'TILED': true},
       serverType: 'geoserver',
       crossOrigin: 'anonymous'

--- a/examples/synthvectors.js
+++ b/examples/synthvectors.js
@@ -52,7 +52,7 @@ var addFeatures = function() {
 
 var tile = new ol.layer.Tile({
   source: new ol.source.TileWMS({
-    url: 'http://demo.opengeo.org/geoserver/wms',
+    url: 'http://demo.boundlessgeo.com/geoserver/wms',
     params: {
       'LAYERS': 'ne:NE1_HR_LC_SR_W_DR'
     }

--- a/examples/synthvectors_batch.js
+++ b/examples/synthvectors_batch.js
@@ -55,7 +55,7 @@ var addFeatures = function() {
 
 var tile = new ol.layer.Tile({
   source: new ol.source.TileWMS({
-    url: 'http://demo.opengeo.org/geoserver/wms',
+    url: 'http://demo.boundlessgeo.com/geoserver/wms',
     params: {
       'LAYERS': 'ne:NE1_HR_LC_SR_W_DR'
     }


### PR DESCRIPTION
Currently demo.opengeo.org redirects to demo.boundlessgeo.com. This change
makes it so demo.boundlessgeo.com is used directly.
