### PR TITLE
Manage null value of prims variable

### DIFF
--- a/src/featureconverter.js
+++ b/src/featureconverter.js
@@ -1025,7 +1025,7 @@ olcs.FeatureConverter.prototype.olVectorLayerToCesium = function(olLayer, olView
       if (prims) {
         if (!primitives) {
           primitives = prims;
-        } else {
+        } else if (prims) {
           let i = 0, prim;
           while ((prim = prims.get(i))) {
             primitives.add(prim);


### PR DESCRIPTION
`olFeatureToCesium` can return null value, when it is the case `prims.get` returns a js error.