### PR TITLE
Depend on OpenLayers and Cesium through npm

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,0 @@
-[submodule "ol"]
-	path = ol
-	url = https://github.com/openlayers/openlayers.git
-[submodule "cesium"]
-	path = cesium
-	url = https://github.com/AnalyticalGraphicsInc/cesium.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,8 @@ cache:
   directories:
     - node_modules
 
-git:
-  submodules: false
-
-before_install:
-  - git submodule update --init ol
-
 script:
-  - NO_CESIUM=1 make dist
-  - NO_CESIUM=1 make check
-  - NO_CESIUM=1 make dist-examples
+  - make dist
+  - make check
+  - make dist-examples
   - ./build/goog-count.sh

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,12 @@
 
 * Changes
   * Update OpenLayers to v4.3.1 to fix https://github.com/openlayers/ol-cesium/issues/479
+  * Get OpenLayers and Cesium dependencies through npm instead of git
+    submodules. On old clones you must remove manually the unused "ol" and
+    "cesium" directories.
+  * Switch to @camptocamp/closure-util fork to allow using goog.modules.
+  * Switch to @camptocamp/cesium to allow examples based on vector tiles and
+    advanced performance optimizations.
 
 # v 1.30 - 2017-08-03
 

--- a/build/build.js
+++ b/build/build.js
@@ -4,7 +4,7 @@
 var path = require('path');
 
 var async = require('async');
-var closure = require('closure-util');
+var closure = require('@camptocamp/closure-util');
 var fs = require('fs-extra');
 var nomnom = require('nomnom');
 var exec = require('child_process').exec;
@@ -168,7 +168,7 @@ function build(config, paths, callback) {
     concatenate(paths, callback);
   } else {
     log.info('ol-cesium', 'Compiling ' + paths.length + ' sources');
-    paths = paths.concat('ol/src/ol/typedefs.js');
+    paths = paths.concat('node_modules/openlayers/src/ol/typedefs.js');
     options.compile.js = paths.concat(options.compile.js || []);
     closure.compile(options, callback);
   }

--- a/build/generate-info.js
+++ b/build/generate-info.js
@@ -7,7 +7,7 @@ var fse = require('fs-extra');
 var walk = require('walk').walk;
 var isWindows = process.platform.indexOf('win') === 0;
 
-var sourceDirOL = path.join(__dirname, '..', 'ol', 'src');
+var sourceDirOL = path.join(__dirname, '..', 'node_modules', 'openlayers', 'src');
 var sourceDirSelf = path.join(__dirname, '..', 'src');
 var sourceDirs = [sourceDirOL, sourceDirSelf];
 var infoPath = path.join(__dirname, '..', '.build', 'info.json');

--- a/build/olcesium-debug.json
+++ b/build/olcesium-debug.json
@@ -1,8 +1,8 @@
 {
   "src": [
     "src/**/*.js",
-    "ol/src/**/*.js",
-    "ol/build/ol.ext/*.js"
+    "node_modules/openlayers/src/**/*.js",
+    "node_modules/openlayers/build/ol.ext/*.js"
   ],
   "exports": ["*"]
 }

--- a/build/olcesium.json
+++ b/build/olcesium.json
@@ -2,22 +2,22 @@
   "exports": ["*"],
   "src": [
     "src/**/*.js",
-    "ol/src/**/*.js",
-    "ol/build/ol.ext/*.js"
+    "node_modules/openlayers/src/**/*.js",
+    "node_modules/openlayers/build/ol.ext/*.js"
   ],
   "compile": {
     "externs": [
       "externs/olcsx.js",
-      "ol/externs/oli.js",
-      "ol/externs/olx.js",
-      "ol/externs/cartodb.js",
-      "ol/externs/proj4js.js",
-      "ol/externs/tilejson.js",
-      "ol/externs/topojson.js",
-      "ol/externs/esrijson.js",
-      "ol/externs/geojson.js",
-      "ol/externs/bingmaps.js",
-      "ol/externs/closure-compiler.js",
+      "node_modules/openlayers/externs/oli.js",
+      "node_modules/openlayers/externs/olx.js",
+      "node_modules/openlayers/externs/cartodb.js",
+      "node_modules/openlayers/externs/proj4js.js",
+      "node_modules/openlayers/externs/tilejson.js",
+      "node_modules/openlayers/externs/topojson.js",
+      "node_modules/openlayers/externs/esrijson.js",
+      "node_modules/openlayers/externs/geojson.js",
+      "node_modules/openlayers/externs/bingmaps.js",
+      "node_modules/openlayers/externs/closure-compiler.js",
       "Cesium.externs.js"
     ],
     "js": [

--- a/build/serve.js
+++ b/build/serve.js
@@ -1,7 +1,7 @@
 var path = require('path');
 var url = require('url');
 
-var closure = require('closure-util');
+var closure = require('@camptocamp/closure-util');
 var nomnom = require('nomnom');
 
 var log = closure.log;
@@ -31,8 +31,8 @@ var manager = new closure.Manager({
   closure: true, // use the bundled Closure Library
   lib: [
     'src/**/*.js',
-    'ol/src/**/*.js',
-    'ol/build/ol.ext/*.js'
+    'node_modules/openlayers/src/**/*.js',
+    'node_modules/openlayers/build/ol.ext/*.js'
   ]
 });
 manager.on('error', function(e) {

--- a/examples/exports.html
+++ b/examples/exports.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="robots" content="index, all" />
     <title>olcesium exported methods example</title>
-    <link rel="stylesheet" href="../ol/css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css">
   </head>
   <body>
     <div id="map" style="width:600px;height:400px;float:left;"></div>

--- a/examples/inject_ol_cesium.js
+++ b/examples/inject_ol_cesium.js
@@ -6,7 +6,7 @@
   const ol = (DIST && isDev) ? 'olcesium-debug.js' : '@loader';
 
   if (!window.LAZY_CESIUM) {
-    document.write(`${'<scr' + 'ipt type="text/javascript" src="../cesium/Build/'}${cs}"></scr` + 'ipt>');
+    document.write(`${'<scr' + 'ipt type="text/javascript" src="../node_modules/@camptocamp/cesium/Build/'}${cs}"></scr` + 'ipt>');
   }
   document.write(`${'<scr' + 'ipt type="text/javascript" src="../'}${ol}"></scr` + 'ipt>');
 

--- a/examples/kml.html
+++ b/examples/kml.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="robots" content="index, all" />
     <title>olcesium kml example</title>
-    <link rel="stylesheet" href="../ol/css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css">
   </head>
   <body>
     <div id="map" style="width:600px;height:400px;"></div>

--- a/examples/lazy.html
+++ b/examples/lazy.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="robots" content="index, all" />
     <title>olcesium lazy initialization</title>
-    <link rel="stylesheet" href="../ol/css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css">
   </head>
   <body>
     <div>Delay downloading the Cesium script and initializing the 3D globe.</div>

--- a/examples/main.html
+++ b/examples/main.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="robots" content="index, all" />
     <title>olcesium example</title>
-    <link rel="stylesheet" href="../ol/css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css">
   </head>
   <body>
     <div id="map" style="width:600px;height:400px;"></div>

--- a/examples/rastersync.html
+++ b/examples/rastersync.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="robots" content="index, all" />
     <title>olcesium raster layer synchronization example</title>
-    <link rel="stylesheet" href="../ol/css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css">
     <style>
       fieldset {display:inline-block;float:left;}
       label {display:block;}

--- a/examples/rotate.html
+++ b/examples/rotate.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="robots" content="index, all" />
     <title>olcesium animated rotation example</title>
-    <link rel="stylesheet" href="../ol/css/ol.css" type="text/css"></link>
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css"></link>
     <style>.cesium-credit-textContainer { display: inline-block; font-size: 50%; line-height: 100%;}</style>
   </head>
   <body>

--- a/examples/selection.html
+++ b/examples/selection.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="robots" content="index, all" />
     <title>olcesium selection example</title>
-    <link rel="stylesheet" href="../ol/css/ol.css" type="text/css"></link>
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css"></link>
   </head>
   <body>
     <div id="map2d" style="width:600px;height:400px;float:left;"></div>

--- a/examples/sidebyside.html
+++ b/examples/sidebyside.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="robots" content="index, all" />
     <title>olcesium side-by-side example</title>
-    <link rel="stylesheet" href="../ol/css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css">
   </head>
   <body>
     <div id="map2d" style="width:600px;height:400px;float:left;"></div>

--- a/examples/synthvectors_batch.html
+++ b/examples/synthvectors_batch.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="robots" content="index, all" />
     <title>olcesium synthetic vector layer example using several layers</title>
-    <link rel="stylesheet" href="../ol/css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css">
   </head>
   <body>
     <div id="map2d" style="width:600px;height:400px;float:left;"></div>

--- a/examples/tracking.html
+++ b/examples/tracking.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="robots" content="index, all" />
     <title>olcesium tracking example</title>
-    <link rel="stylesheet" href="../ol/css/ol.css" type="text/css"></link>
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css"></link>
     <style>.cesium-credit-textContainer { display: inline-block; font-size: 50%; line-height: 100%;}</style>
   </head>
   <body>

--- a/examples/vectors.html
+++ b/examples/vectors.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="robots" content="index, all" />
     <title>olcesium vectors example</title>
-    <link rel="stylesheet" href="../ol/css/ol.css" type="text/css"></link>
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css"></link>
     <style>.cesium-credit-textContainer { display: inline-block; font-size: 50%; line-height: 100%;}</style>
   </head>
   <body>

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "htmlparser2": "3.9.2"
   },
   "devDependencies": {
-    "closure-util": "1.22.0",
+    "@camptocamp/closure-util": "1.23.0",
+    "openlayers": "4.3.1",
+    "@camptocamp/cesium": "1.36.0",
     "@mapbox/geojsonhint": "2.0.1",
     "fs-extra": "3.0.1",
     "jsdoc": "~3.4.0",


### PR DESCRIPTION
Switch to @camptocamp/closure-util to allow usage of goog.modules.
Applications using closure will need to switch to @camptocamp/closure-util.
In the middle term the dependency on closure-util will be removed in favour of pure ES6 modules.

Switch to @camptocamp/cesium to allow writing examples using Cesium vector tiles or advanced optimizations.