### PR TITLE
synchronize nested ol.layer.group Items

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,8 +4,10 @@
 # v 1.32
 
 * Breaking changes
-  * Changed dAbstractSynchronizer.createSingleLayerCounterparts Plugin API
+  * Changed AbstractSynchronizer.createSingleLayerCounterparts Plugin API
     in existing plugins the function has to be modified.
+    It now takes an object {layer: !ol.layer.Base, parents: Array<ol.layer.Group>}.
+    The parents are ordered with the first parent coming first and the last parent coming last.
 
 * Changes
   * Allow features to specify a dedicated geometry for rendering in Cesium

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 
 # v 1.32
 
+* Breaking changes
+  * Changed dAbstractSynchronizer.createSingleLayerCounterparts Plugin API
+    in existing plugins the function has to be modified.
+
 * Changes
   * Allow features to specify a dedicated geometry for rendering in Cesium
     using the `olcs.3d_geometry` property.
@@ -13,6 +17,7 @@
     initialization of an application. olcs.contrib.Manager is an abstract class
     which must be extended before use.
   * Added calcResolutionForDistance and calcDistanceForResolution functions to Camera API
+  * Added ol.layer.Group synchronization
 
 # v 1.31 - 2017-09-06
 

--- a/examples/layer-group.html
+++ b/examples/layer-group.html
@@ -1,0 +1,72 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE HTML>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="robots" content="index, all" />
+    <title>olcesium layergroup synchronization</title>
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css">
+    <style>
+      #layertree li > span {
+        cursor: pointer;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="map2d" style="width:600px;height:400px;float:left;"></div>
+    <div id="map3d" style="width:600px;height:400px;float:left;position:relative;"></div>
+    <div id="layertree" style="position:absolute;top:400px">
+      <h5>Click on layer nodes below to change their properties.</h5>
+      <ul>
+        <li><span>OSM layer</span>
+          <fieldset id="layer0">
+            <label class="checkbox" for="visible0">
+              <input id="visible0" class="visible" onchange="toggleLayer(this, layer0)" type="checkbox" checked/>
+              visibility
+            </label>
+            <label>opacity</label>
+            <input class="opacity" type="range" min="0" max="1" step="0.01" value="1"
+                   onchange="setLayerOpacity(this, layer0);" oninput="setLayerOpacity(this, layer0);"/>
+          </fieldset>
+        </li>
+        <li><span>Layer group</span>
+          <fieldset id="layer1">
+            <label class="checkbox" for="visible1">
+              <input id="visible1" class="visible" onchange="toggleLayer(this, layer1)" type="checkbox" checked/>
+              visibility
+            </label>
+            <label>opacity</label>
+            <input class="opacity" type="range" min="0" max="1" step="0.01" value="1"
+                   onchange="setLayerOpacity(this, layer1);" oninput="setLayerOpacity(this, layer1);"/>
+          </fieldset>
+          <ul>
+            <li><span>Food insecurity layer</span>
+              <fieldset id="layer10">
+                <label class="checkbox" for="visible10">
+                  <input id="visible10" class="visible" onchange="toggleLayer(this, layer10)" type="checkbox" checked/>
+                  visibility
+                </label>
+                <label>opacity</label>
+                <input class="opacity" type="range" min="0" max="1" step="0.01" value="1"
+                       onchange="setLayerOpacity(this, layer10);" oninput="setLayerOpacity(this, layer10);"/>
+              </fieldset>
+            </li>
+            <li><span>World borders layer</span>
+              <fieldset id="layer11">
+                <label class="checkbox" for="visible11">
+                  <input id="visible11" class="visible" onchange="toggleLayer(this, layer11)" type="checkbox" checked/>
+                  visibility
+                </label>
+                <label>opacity</label>
+                <input class="opacity" type="range" min="0" max="1" step="0.01" value="1"
+                       onchange="setLayerOpacity(this, layer11);" oninput="setLayerOpacity(this, layer11);"/>
+              </fieldset>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </div>
+    <script src="inject_ol_cesium.js"></script>
+    <script src="layer-group.js"></script>
+  </body>
+</html>

--- a/examples/layer-group.js
+++ b/examples/layer-group.js
@@ -1,0 +1,58 @@
+/* eslint googshift/valid-provide-and-module: 0 */
+
+goog.provide('examples.layer-group');
+
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.layer.Group');
+goog.require('ol.layer.Tile');
+goog.require('ol.proj');
+goog.require('ol.source.OSM');
+goog.require('ol.source.TileJSON');
+goog.require('olcs.OLCesium');
+
+const layer0 = new ol.layer.Tile({
+  source: new ol.source.OSM()
+});
+
+const layer10 = new ol.layer.Tile({
+  source: new ol.source.TileJSON({
+    url: 'https://api.tiles.mapbox.com/v3/mapbox.20110804-hoa-foodinsecurity-3month.json?secure',
+    crossOrigin: 'anonymous'
+  })
+});
+
+const layer11 = new ol.layer.Tile({
+  source: new ol.source.TileJSON({
+    url: 'https://api.tiles.mapbox.com/v3/mapbox.world-borders-light.json?secure',
+    crossOrigin: 'anonymous'
+  })
+});
+
+const layer1 = new ol.layer.Group({
+  layers: [
+    layer10,
+    layer11
+  ]
+});
+
+const ol2d = new ol.Map({
+  layers: [layer0, layer1],
+  target: 'map2d',
+  view: new ol.View({
+    center: ol.proj.fromLonLat([37.40570, 8.81566]),
+    zoom: 4
+  })
+});
+
+const ol3d = new olcs.OLCesium({map: ol2d, target: 'map3d'});
+ol3d.setEnabled(true);
+
+// eslint-disable-next-line no-unused-vars
+function toggleLayer(element, layer) {
+  layer.setVisible(element.checked);
+}
+// eslint-disable-next-line no-unused-vars
+function setLayerOpacity(element, layer) {
+  layer.setOpacity(parseFloat(element.value));
+}

--- a/externs/olcsx.js
+++ b/externs/olcsx.js
@@ -101,3 +101,12 @@ olcsx.core.RotateAroundAxisOption;
  * @api
  */
 olcsx.core.CesiumUrlDefinition;
+
+
+/**
+ * @typedef {{
+ *  layer: !ol.layer.Base,
+ *  parents: Array<ol.layer.Group>
+ * }}
+ */
+olcsx.LayerWithParents;

--- a/src/olcs/core.js
+++ b/src/olcs/core.js
@@ -407,19 +407,25 @@ olcs.core.tileLayerToImageryLayer = function(olLayer, viewProj) {
 /**
  * Synchronizes the layer rendering properties (opacity, visible)
  * to the given Cesium ImageryLayer.
- * @param {!ol.layer.Base} olLayer
- * @param {!Cesium.ImageryLayer} csLayer
+ * @param {Array.<!ol.layer.Base>} olLayerList
+ * @param {!Cesium.ImageryLayer | !Cesium.Primitive} csLayer
  * @api
  */
-olcs.core.updateCesiumLayerProperties = function(olLayer, csLayer) {
-  const opacity = olLayer.getOpacity();
-  if (opacity !== undefined) {
-    csLayer.alpha = opacity;
-  }
-  const visible = olLayer.getVisible();
-  if (visible !== undefined) {
-    csLayer.show = visible;
-  }
+olcs.core.updateCesiumLayerProperties = function(olLayerList, csLayer) {
+  let opacity = 1;
+  let visible = true;
+  olLayerList.forEach((olLayer) => {
+    const layerOpacity = olLayer.getOpacity();
+    if (layerOpacity !== undefined) {
+      opacity *= layerOpacity;
+    }
+    const layerVisible = olLayer.getVisible();
+    if (layerVisible !== undefined) {
+      visible &= layerVisible;
+    }
+  });
+  csLayer.alpha = opacity;
+  csLayer.show = visible;
 };
 
 

--- a/src/olcs/core.js
+++ b/src/olcs/core.js
@@ -407,14 +407,14 @@ olcs.core.tileLayerToImageryLayer = function(olLayer, viewProj) {
 /**
  * Synchronizes the layer rendering properties (opacity, visible)
  * to the given Cesium ImageryLayer.
- * @param {Array.<!ol.layer.Base>} olLayerList
- * @param {!Cesium.ImageryLayer | !Cesium.Primitive} csLayer
+ * @param {olcsx.LayerWithParents} olLayerWithParents
+ * @param {!Cesium.ImageryLayer} csLayer
  * @api
  */
-olcs.core.updateCesiumLayerProperties = function(olLayerList, csLayer) {
+olcs.core.updateCesiumLayerProperties = function(olLayerWithParents, csLayer) {
   let opacity = 1;
   let visible = true;
-  olLayerList.forEach((olLayer) => {
+  [olLayerWithParents.layer].concat(olLayerWithParents.parents).forEach((olLayer) => {
     const layerOpacity = olLayer.getOpacity();
     if (layerOpacity !== undefined) {
       opacity *= layerOpacity;

--- a/src/olcs/rastersynchronizer.js
+++ b/src/olcs/rastersynchronizer.js
@@ -94,23 +94,25 @@ olcs.RasterSynchronizer.prototype.convertLayerToCesiumImageries = function(olLay
 /**
  * @inheritDoc
  */
-olcs.RasterSynchronizer.prototype.createSingleLayerCounterparts = function(olLayer) {
+olcs.RasterSynchronizer.prototype.createSingleLayerCounterparts = function(olLayerList) {
+  const olLayer = olLayerList[0];
   const uid = ol.getUid(olLayer).toString();
   const viewProj = this.view.getProjection();
   const cesiumObjects = this.convertLayerToCesiumImageries(olLayer, viewProj);
   if (cesiumObjects) {
     const listenKeyArray = [];
-    listenKeyArray.push(olLayer.on(['change:opacity', 'change:visible'],
-        (e) => {
-          // the compiler does not seem to be able to infer this
-          goog.asserts.assert(cesiumObjects);
-          for (let i = 0; i < cesiumObjects.length; ++i) {
-            olcs.core.updateCesiumLayerProperties(olLayer, cesiumObjects[i]);
-          }
-        }));
+    olLayerList.forEach((olLayerItem) => {
+      listenKeyArray.push(olLayerItem.on(['change:opacity', 'change:visible'], (e) => {
+        // the compiler does not seem to be able to infer this
+        goog.asserts.assert(cesiumObjects);
+        for (let i = 0; i < cesiumObjects.length; ++i) {
+          olcs.core.updateCesiumLayerProperties(olLayerList, cesiumObjects[i]);
+        }
+      }));
+    });
 
     for (let i = 0; i < cesiumObjects.length; ++i) {
-      olcs.core.updateCesiumLayerProperties(olLayer, cesiumObjects[i]);
+      olcs.core.updateCesiumLayerProperties(olLayerList, cesiumObjects[i]);
     }
 
     // there is no way to modify Cesium layer extent,

--- a/src/olcs/rastersynchronizer.js
+++ b/src/olcs/rastersynchronizer.js
@@ -94,25 +94,25 @@ olcs.RasterSynchronizer.prototype.convertLayerToCesiumImageries = function(olLay
 /**
  * @inheritDoc
  */
-olcs.RasterSynchronizer.prototype.createSingleLayerCounterparts = function(olLayerList) {
-  const olLayer = olLayerList[0];
+olcs.RasterSynchronizer.prototype.createSingleLayerCounterparts = function(olLayerWithParents) {
+  const olLayer = olLayerWithParents.layer;
   const uid = ol.getUid(olLayer).toString();
   const viewProj = this.view.getProjection();
   const cesiumObjects = this.convertLayerToCesiumImageries(olLayer, viewProj);
   if (cesiumObjects) {
     const listenKeyArray = [];
-    olLayerList.forEach((olLayerItem) => {
-      listenKeyArray.push(olLayerItem.on(['change:opacity', 'change:visible'], (e) => {
+    [olLayerWithParents.layer].concat(olLayerWithParents.parents).forEach((olLayerItem) => {
+      listenKeyArray.push(olLayerItem.on(['change:opacity', 'change:visible'], () => {
         // the compiler does not seem to be able to infer this
         goog.asserts.assert(cesiumObjects);
         for (let i = 0; i < cesiumObjects.length; ++i) {
-          olcs.core.updateCesiumLayerProperties(olLayerList, cesiumObjects[i]);
+          olcs.core.updateCesiumLayerProperties(olLayerWithParents, cesiumObjects[i]);
         }
       }));
     });
 
     for (let i = 0; i < cesiumObjects.length; ++i) {
-      olcs.core.updateCesiumLayerProperties(olLayerList, cesiumObjects[i]);
+      olcs.core.updateCesiumLayerProperties(olLayerWithParents, cesiumObjects[i]);
     }
 
     // there is no way to modify Cesium layer extent,

--- a/src/olcs/vectorsynchronizer.js
+++ b/src/olcs/vectorsynchronizer.js
@@ -86,12 +86,12 @@ olcs.VectorSynchronizer.prototype.removeAllCesiumObjects = function(destroy) {
 /**
  * Synchronizes the layer visibility properties
  * to the given Cesium Primitive.
- * @param {Array.<!ol.layer.Base>} olLayerList
+ * @param {olcsx.LayerWithParents} olLayerWithParents
  * @param {!Cesium.Primitive} csPrimitive
  */
-olcs.VectorSynchronizer.prototype.updateLayerVisibility = function(olLayerList, csPrimitive) {
+olcs.VectorSynchronizer.prototype.updateLayerVisibility = function(olLayerWithParents, csPrimitive) {
   let visible = true;
-  olLayerList.forEach((olLayer) => {
+  [olLayerWithParents.layer].concat(olLayerWithParents.parents).forEach((olLayer) => {
     const layerVisible = olLayer.getVisible();
     if (layerVisible !== undefined) {
       visible &= layerVisible;
@@ -104,8 +104,8 @@ olcs.VectorSynchronizer.prototype.updateLayerVisibility = function(olLayerList, 
 /**
  * @inheritDoc
  */
-olcs.VectorSynchronizer.prototype.createSingleLayerCounterparts = function(olLayerList) {
-  const olLayer = olLayerList[0];
+olcs.VectorSynchronizer.prototype.createSingleLayerCounterparts = function(olLayerWithParents) {
+  const olLayer = olLayerWithParents.layer;
   if (!(olLayer instanceof ol.layer.Vector) &&
       !(olLayer instanceof ol.layer.Image &&
       olLayer.getSource() instanceof ol.source.ImageVector)) {
@@ -131,12 +131,12 @@ olcs.VectorSynchronizer.prototype.createSingleLayerCounterparts = function(olLay
   const csPrimitives = counterpart.getRootPrimitive();
   const olListenKeys = counterpart.olListenKeys;
 
-  olLayerList.forEach((olLayerItem) => {
+  [olLayerWithParents.layer].concat(olLayerWithParents.parents).forEach((olLayerItem) => {
     olListenKeys.push(ol.events.listen(olLayerItem, 'change:visible', () => {
-      this.updateLayerVisibility(olLayerList, csPrimitives);
+      this.updateLayerVisibility(olLayerWithParents, csPrimitives);
     }));
   });
-  this.updateLayerVisibility(olLayerList, csPrimitives);
+  this.updateLayerVisibility(olLayerWithParents, csPrimitives);
 
   const onAddFeature = (function(feature) {
     goog.asserts.assert(


### PR DESCRIPTION
Hi, 
we are at the moment working on a project to integrate 3D in the 2D gis portal of Hamburg. For this we are using ol-cesium, but we had to add some functionality and now want to integrate the changes in the project. 
For better review purposes i will create several pull requests. 

Here we changed the code to also synchronize nested ol.layer.group Items. 


Link to the hamburg application: https://www.geoportal-hamburg.de/Geoportal/geo-online/
Link to the Hamburg application source code: https://bitbucket.org/lgv-g12/lgv

This work is paid by the Agency for Geoinformation and Surveying (LGV) Hamburg
http://www.hamburg.de/bsw/whoweare/


Jannes