### PR TITLE
Do not use cluster source, but the underlying feature source

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 * Changes
   * Enable googshift eslint rules to prepare for ES6 modules migration; move
     source to the olcs directory and fix filenames.
+  * Add basic support for clustered sources: see https://github.com/openlayers/ol-cesium/pull/496.
 
 
 # v 1.31 - 2017-09-06

--- a/src/olcs/featureconverter.js
+++ b/src/olcs/featureconverter.js
@@ -4,6 +4,7 @@ goog.require('ol.geom.Geometry');
 goog.require('ol.source.ImageVector');
 goog.require('ol.style.Icon');
 goog.require('ol.source.Vector');
+goog.require('ol.source.Cluster');
 
 goog.require('goog.asserts');
 goog.require('ol');
@@ -992,6 +993,9 @@ olcs.FeatureConverter.prototype.olVectorLayerToCesium = function(olLayer, olView
       // Not supported
       return new olcs.core.VectorLayerCounterpart(proj, this.scene);
     }
+  }
+  if (source instanceof ol.source.Cluster) {
+    source = source.getSource();
   }
 
   goog.asserts.assertInstanceof(source, ol.source.Vector);

--- a/src/olcs/vectorsynchronizer.js
+++ b/src/olcs/vectorsynchronizer.js
@@ -2,6 +2,7 @@ goog.provide('olcs.VectorSynchronizer');
 goog.require('ol.source.Vector');
 goog.require('ol.layer.Layer');
 goog.require('ol.source.ImageVector');
+goog.require('ol.source.Cluster');
 goog.require('ol.layer.Image');
 
 goog.require('goog.asserts');
@@ -96,6 +97,9 @@ olcs.VectorSynchronizer.prototype.createSingleLayerCounterparts = function(olLay
 
   let source = olLayer.getSource();
   if (source instanceof ol.source.ImageVector) {
+    source = source.getSource();
+  }
+  if (source instanceof ol.source.Cluster) {
     source = source.getSource();
   }
 


### PR DESCRIPTION
next PR for the city of hamburg project see #494

this fixes https://github.com/openlayers/ol-cesium/issues/493

we changed the handling of cluster sources. As a first iteration we use the real features to convert to cesium. 

As a second iteration someone could intergrate the cesium clustering support.

Jannes