### PR TITLE
Add main entry in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.32.0",
   "description": "OpenLayers Cesium integration library",
   "scripts": {},
+  "main": "./dist/olcesium.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/openlayers/ol-cesium.git"


### PR DESCRIPTION
Hello,

In order to import ol-cesium in our Angular application, it needs to register a "main" entry in the package.json.

Thanks