### PR TITLE
Stop OpenLayers events propagation with a flag

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
   * Animate olcs.contrib.Manager#toggle3d.
   * Add support for Overlay synchronization, see example Overlays.
   * Port to Cesium 1.39.
+  * Restore OpenLayers events propagation.
 
 
 # v 1.32 - 2017-10-26

--- a/externs/olcsx.js
+++ b/externs/olcsx.js
@@ -12,6 +12,7 @@ var olcsx;
  *   target: (Element|string|undefined),
  *   createSynchronizers: (undefined|function(!ol.Map, !Cesium.Scene, !Cesium.DataSourceCollection): Array.<olcs.AbstractSynchronizer>),
  *   time: (undefined|function(): Cesium.JulianDate),
+ *   stopOpenLayersEventsPropagation: (boolean|undefined),
  *   sceneOptions: (Cesium.SceneOptions|undefined)
  * }}
  * @api
@@ -47,7 +48,6 @@ olcsx.OLCesiumOptions.prototype.sceneOptions;
  */
 olcsx.OLCesiumOptions.prototype.target;
 
-
 /**
  * Callback function which will be called by the {@link olcs.OLCesium}
  * constructor to create custom synchronizers. Receives an `ol.Map` and a
@@ -57,6 +57,12 @@ olcsx.OLCesiumOptions.prototype.target;
  * @api
  */
 olcsx.OLCesiumOptions.prototype.createSynchronizers;
+
+/**
+ * Prevent propagation of mouse/touch events to OpenLayers when Cesium is active.
+ * @type {boolean|undefined}
+ */
+olcsx.OLCesiumOptions.prototype.stopOpenLayersEventsPropagation;
 
 
 /**

--- a/src/olcs/olcesium.js
+++ b/src/olcs/olcesium.js
@@ -106,7 +106,7 @@ olcs.OLCesium = function(options) {
   this.isOverMap_ = !targetElement;
 
 
-  if (this.isOverMap_) {
+  if (this.isOverMap_ && options.stopOpenLayersEventsPropagation) {
     const overlayEvents = [
       ol.events.EventType.CLICK,
       ol.events.EventType.DBLCLICK,


### PR DESCRIPTION
The goal of OL-Cesium is to unify interacting with OpenLayers and Cesium.
Letting the events be propagated to OpenLayers allows to have a single listener in application code, designed around the OpenLayers API.