### PR TITLE
Remove management of ol.source.ImageVector

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 * Changes
   * Animate olcs.contrib.Manager#toggle3d.
   * Add support for Overlay synchronization, see example Overlays.
-  * Port to Cesium 1.39.
+  * Port to OpenLayers 4.6.2 and Cesium 1.39.
   * Restore OpenLayers events propagation.
   * Workaround camera sinking under the terrain and finally jumping above it.
     See https://github.com/AnalyticalGraphicsInc/cesium/issues/5999. The

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
     See https://github.com/AnalyticalGraphicsInc/cesium/issues/5999. The
     workaround requires the Camptocamp version of Cesium (otherwise it has no effect).
   * Add preliminary work for an ES6 package https://www.npmjs.com/package/olcs.
+  * Remove management of ol.source.ImageVector. This class is deprecated in OpenLayers 4.6.2.
 
 
 # v 1.32 - 2017-10-26

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "googshift": "0.9.2",
     "jsdoc": "3.5.5",
     "nomnom": "1.8.1",
-    "openlayers": "4.6.0",
+    "openlayers": "4.6.2",
     "temp": "0.8.3",
     "walk": "2.3.9"
   }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "googshift": "0.9.2",
     "jsdoc": "3.5.5",
     "nomnom": "1.8.1",
-    "openlayers": "4.5.0",
+    "openlayers": "openlayers/openlayers#8afcd1c",
     "temp": "0.8.3",
     "walk": "2.3.9"
   }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "googshift": "0.9.2",
     "jsdoc": "3.5.5",
     "nomnom": "1.8.1",
-    "openlayers": "openlayers/openlayers#8afcd1c",
+    "openlayers": "4.6.0",
     "temp": "0.8.3",
     "walk": "2.3.9"
   }

--- a/src/olcs/featureconverter.js
+++ b/src/olcs/featureconverter.js
@@ -1,7 +1,5 @@
 goog.provide('olcs.FeatureConverter');
-goog.require('ol.layer.Image');
 goog.require('ol.geom.Geometry');
-goog.require('ol.source.ImageVector');
 goog.require('ol.style.Icon');
 goog.require('ol.source.Vector');
 goog.require('ol.source.Cluster');
@@ -587,10 +585,7 @@ olcs.FeatureConverter.prototype.olPointGeometryToCesium = function(layer, featur
     if (image instanceof Image && !isImageLoaded(image)) {
       // Cesium requires the image to be loaded
       let cancelled = false;
-      let source = layer.getSource();
-      if (source instanceof ol.source.ImageVector) {
-        source = source.getSource();
-      }
+      const source = layer.getSource();
       const canceller = function() {
         cancelled = true;
       };
@@ -1007,14 +1002,6 @@ olcs.FeatureConverter.prototype.olVectorLayerToCesium = function(olLayer, olView
   }
 
   let source = olLayer.getSource();
-  if (olLayer instanceof ol.layer.Image) {
-    if (source instanceof ol.source.ImageVector) {
-      source = source.getSource();
-    } else {
-      // Not supported
-      return new olcs.core.VectorLayerCounterpart(proj, this.scene);
-    }
-  }
   if (source instanceof ol.source.Cluster) {
     source = source.getSource();
   }
@@ -1031,14 +1018,7 @@ olcs.FeatureConverter.prototype.olVectorLayerToCesium = function(olLayer, olView
     /**
      * @type {ol.StyleFunction|undefined}
      */
-    let layerStyle;
-    if (olLayer instanceof ol.layer.Image) {
-      const imageSource = olLayer.getSource();
-      goog.asserts.assertInstanceof(imageSource, ol.source.ImageVector);
-      layerStyle = imageSource.getStyleFunction();
-    } else {
-      layerStyle = olLayer.getStyleFunction();
-    }
+    const layerStyle = olLayer.getStyleFunction();
     const styles = this.computePlainStyle(olLayer, feature, layerStyle,
         resolution);
     if (!styles || !styles.length) {
@@ -1095,17 +1075,7 @@ olcs.FeatureConverter.prototype.convert = function(layer, view, feature, context
   /**
    * @type {ol.StyleFunction|undefined}
    */
-  let layerStyle;
-  if (layer instanceof ol.layer.Image) {
-    const imageSource = layer.getSource();
-    if (imageSource instanceof ol.source.ImageVector) {
-      layerStyle = imageSource.getStyleFunction();
-    } else {
-      return null;
-    }
-  } else {
-    layerStyle = layer.getStyleFunction();
-  }
+  const layerStyle = layer.getStyleFunction();
 
   const styles = this.computePlainStyle(layer, feature, layerStyle, resolution);
 

--- a/src/olcs/vectorsynchronizer.js
+++ b/src/olcs/vectorsynchronizer.js
@@ -1,7 +1,6 @@
 goog.provide('olcs.VectorSynchronizer');
 goog.require('ol.source.Vector');
 goog.require('ol.layer.Layer');
-goog.require('ol.source.ImageVector');
 goog.require('ol.source.Cluster');
 goog.require('ol.layer.Image');
 
@@ -106,17 +105,12 @@ olcs.VectorSynchronizer.prototype.updateLayerVisibility = function(olLayerWithPa
  */
 olcs.VectorSynchronizer.prototype.createSingleLayerCounterparts = function(olLayerWithParents) {
   const olLayer = olLayerWithParents.layer;
-  if (!(olLayer instanceof ol.layer.Vector) &&
-      !(olLayer instanceof ol.layer.Image &&
-      olLayer.getSource() instanceof ol.source.ImageVector)) {
+  if (!(olLayer instanceof ol.layer.Vector)) {
     return null;
   }
   goog.asserts.assertInstanceof(olLayer, ol.layer.Layer);
 
   let source = olLayer.getSource();
-  if (source instanceof ol.source.ImageVector) {
-    source = source.getSource();
-  }
   if (source instanceof ol.source.Cluster) {
     source = source.getSource();
   }


### PR DESCRIPTION
This PR prepare for v4.6.0 of openlayer removing use of ol.source.ImageVector.