### PR TITLE
Set the eslint as the root config file

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,4 +1,5 @@
 {
+  root: true,
   extends: [
     'openlayers',
     '.eslintrc-es6.yaml'


### PR DESCRIPTION
It's a proposal, When we build ol-cesium in a subfolder , It tries to apply the eslint config from the parent folder. 
Set the root porperty to true avoid this. 