### PR TITLE
Make ol3d load promise always available

### DIFF
--- a/src/olcs/contrib/manager.js
+++ b/src/olcs/contrib/manager.js
@@ -47,10 +47,24 @@ olcs.contrib.Manager = class {
     this.blockLimiter_ = false;
 
     /**
+     * @type {function(Promise.<olcs.OLCesium>)}
+     * @private
+     */
+    this.loadPromiseResolver;
+
+    /**
      * @type {Promise.<olcs.OLCesium>}
      * @private
      */
-    this.promise_;
+    this.loadPromise_ = new Promise((resolve) => {
+      this.loadPromiseResolver = resolve;
+    });
+
+    /**
+     * @type {boolean}
+     * @private
+     */
+    this.waitForLoad_ = false;
 
     /**
      * @type {olcs.OLCesium}
@@ -104,11 +118,21 @@ olcs.contrib.Manager = class {
    * @return {Promise.<olcs.OLCesium>}
    */
   load() {
-    if (!this.promise_) {
+    if (!this.waitForLoad_) {
       const cesiumLazyLoader = new olcs.contrib.LazyLoader(this.cesiumUrl_);
-      this.promise_ = cesiumLazyLoader.load().then(() => this.onCesiumLoaded());
+      this.waitForLoad_ = true;
+      this.loadPromiseResolver(cesiumLazyLoader.load().then(
+          () => this.onCesiumLoaded())
+      );
     }
-    return this.promise_;
+    return this.loadPromise_;
+  }
+
+  /**
+   * @return {Promise.<olcs.OLCesium>}
+   */
+  getLoadPromise() {
+    return this.loadPromise_;
   }
 
 


### PR DESCRIPTION
This PR tries to improve the Cesium lazy load promise mechanism to provide an always available fresh promise that is resolved when load is completed.

The promise is accessible with `getLoadPromise()` method. 

This way anyone can know when load is done without requesting the load.