### PR TITLE
Add 3d toggle & load events in manager

### DIFF
--- a/src/olcs/contrib/manager.js
+++ b/src/olcs/contrib/manager.js
@@ -131,6 +131,7 @@ olcs.contrib.Manager = class extends ol.Observable {
     const scene = this.ol3d.getCesiumScene();
     this.configureForUsability(scene);
     this.configureForPerformance(scene);
+    this.dispatchEvent('load');
     return this.ol3d;
   }
 

--- a/src/olcs/contrib/manager.js
+++ b/src/olcs/contrib/manager.js
@@ -5,16 +5,19 @@ goog.require('olcs.OLCesium');
 goog.require('olcs.core');
 
 goog.require('ol.math');
+goog.require('ol.Observable');
 goog.require('goog.asserts');
 
 
-olcs.contrib.Manager = class {
+olcs.contrib.Manager = class extends ol.Observable {
   /**
    * @param {string} cesiumUrl
    * @param {olcsx.contrib.ManagerOptions} options
    * @api
    */
   constructor(cesiumUrl, {map, cameraExtentInRadians} = {}) {
+
+    super();
 
     /**
      * @type {string}
@@ -229,10 +232,12 @@ olcs.contrib.Manager = class {
         goog.asserts.assert(this.map);
         return olcs.core.resetToNorthZenith(this.map, scene).then(() => {
           ol3d.setEnabled(false);
+          this.dispatchEvent('toggle');
         });
       } else {
         // Enable 3D
         ol3d.setEnabled(true);
+        this.dispatchEvent('toggle');
         return olcs.core.rotateAroundBottomCenter(scene, this.cesiumInitialTilt_);
       }
     });


### PR DESCRIPTION
Add an event when 3D is toggled to the Cesium Manager.

```js
cesiumManager.on('change', (event) => {
  console.log('3D active: ', event.target.is3dEnabled());
});
```
Also add a `LOAD` event when cesium has been loaded.
