### PR TITLE
Retry to add updated layers after they failed once

### DIFF
--- a/src/olcs/abstractsynchronizer.js
+++ b/src/olcs/abstractsynchronizer.js
@@ -159,9 +159,9 @@ olcs.AbstractSynchronizer.prototype.addLayers_ = function(root) {
 
 /**
  * Add Cesium objects.
- * @param cesiumObjects
- * @param layerId
- * @param layer
+ * @param {Array.<T>} cesiumObjects
+ * @param {number} layerId
+ * @param {ol.layer.Base} layer
  * @private
  */
 olcs.AbstractSynchronizer.prototype.addCesiumObjects_ = function(cesiumObjects, layerId, layer) {

--- a/src/olcs/abstractsynchronizer.js
+++ b/src/olcs/abstractsynchronizer.js
@@ -136,9 +136,11 @@ olcs.AbstractSynchronizer.prototype.addLayers_ = function(root) {
         // for example when a source is set after the layer is added to the map
         const layerId = olLayerId;
         const layerWithParents = olLayerWithParents;
-        layerWithParents.layer.on('change', (e) => {
+        const onLayerChange = (e) => {
           const cesiumObjs = this.createSingleLayerCounterparts(layerWithParents);
           if (cesiumObjs) {
+            // unsubscribe event listener
+            layerWithParents.layer.un('change', onLayerChange, this);
             this.layerMap[layerId] = cesiumObjs;
             this.olLayerListenKeys[layerId].push(ol.events.listen(layerWithParents.layer, 'change:zIndex', this.orderLayers, this));
             cesiumObjs.forEach(function(cesiumObject) {
@@ -146,7 +148,8 @@ olcs.AbstractSynchronizer.prototype.addLayers_ = function(root) {
             }, this);
             this.orderLayers();
           }
-        });
+        };
+        layerWithParents.layer.on('change', onLayerChange, this);
       }
     }
     // add Cesium layers

--- a/src/olcs/abstractsynchronizer.js
+++ b/src/olcs/abstractsynchronizer.js
@@ -145,7 +145,7 @@ olcs.AbstractSynchronizer.prototype.addLayers_ = function(root) {
             this.orderLayers();
           }
         };
-        layerWithParents.layer.on('change', onLayerChange, this);
+        this.olLayerListenKeys[olLayerId].push(layerWithParents.layer.on('change', onLayerChange, this));
       }
     }
     // add Cesium layers

--- a/src/olcs/abstractsynchronizer.js
+++ b/src/olcs/abstractsynchronizer.js
@@ -131,6 +131,23 @@ olcs.AbstractSynchronizer.prototype.addLayers_ = function(root) {
       }
     } else {
       cesiumObjects = this.createSingleLayerCounterparts(olLayerWithParents);
+      if (!cesiumObjects) {
+        // keep an eye on the layers that once failed to be added (might work when the layer is updated)
+        // for example when a source is set after the layer is added to the map
+        const layerId = olLayerId;
+        const layerWithParents = olLayerWithParents;
+        layerWithParents.layer.on('change', (e) => {
+          const cesiumObjs = this.createSingleLayerCounterparts(layerWithParents);
+          if (cesiumObjs) {
+            this.layerMap[layerId] = cesiumObjs;
+            this.olLayerListenKeys[layerId].push(ol.events.listen(layerWithParents.layer, 'change:zIndex', this.orderLayers, this));
+            cesiumObjs.forEach(function(cesiumObject) {
+              this.addCesiumObject(cesiumObject);
+            }, this);
+            this.orderLayers();
+          }
+        });
+      }
     }
     // add Cesium layers
     if (cesiumObjects) {

--- a/src/olcs/abstractsynchronizer.js
+++ b/src/olcs/abstractsynchronizer.js
@@ -141,11 +141,7 @@ olcs.AbstractSynchronizer.prototype.addLayers_ = function(root) {
           if (cesiumObjs) {
             // unsubscribe event listener
             layerWithParents.layer.un('change', onLayerChange, this);
-            this.layerMap[layerId] = cesiumObjs;
-            this.olLayerListenKeys[layerId].push(ol.events.listen(layerWithParents.layer, 'change:zIndex', this.orderLayers, this));
-            cesiumObjs.forEach(function(cesiumObject) {
-              this.addCesiumObject(cesiumObject);
-            }, this);
+            this.addCesiumObjects_(cesiumObjs, layerId, layerWithParents.layer);
             this.orderLayers();
           }
         };
@@ -154,15 +150,26 @@ olcs.AbstractSynchronizer.prototype.addLayers_ = function(root) {
     }
     // add Cesium layers
     if (cesiumObjects) {
-      this.layerMap[olLayerId] = cesiumObjects;
-      this.olLayerListenKeys[olLayerId].push(ol.events.listen(olLayer, 'change:zIndex', this.orderLayers, this));
-      cesiumObjects.forEach(function(cesiumObject) {
-        this.addCesiumObject(cesiumObject);
-      }, this);
+      this.addCesiumObjects_(cesiumObjects, olLayerId, olLayer);
     }
   }
 
   this.orderLayers();
+};
+
+/**
+ * Add Cesium objects.
+ * @param cesiumObjects
+ * @param layerId
+ * @param layer
+ * @private
+ */
+olcs.AbstractSynchronizer.prototype.addCesiumObjects_ = function(cesiumObjects, layerId, layer) {
+  this.layerMap[layerId] = cesiumObjects;
+  this.olLayerListenKeys[layerId].push(ol.events.listen(layer, 'change:zIndex', this.orderLayers, this));
+  cesiumObjects.forEach(function(cesiumObject) {
+    this.addCesiumObject(cesiumObject);
+  }, this);
 };
 
 

--- a/src/olcs/abstractsynchronizer.js
+++ b/src/olcs/abstractsynchronizer.js
@@ -145,7 +145,7 @@ olcs.AbstractSynchronizer.prototype.addLayers_ = function(root) {
             this.orderLayers();
           }
         };
-        this.olLayerListenKeys[olLayerId].push(layerWithParents.layer.on('change', onLayerChange, this));
+        this.olLayerListenKeys[olLayerId].push(ol.events.listen(layerWithParents.layer, 'change', onLayerChange, this));
       }
     }
     // add Cesium layers
@@ -160,7 +160,7 @@ olcs.AbstractSynchronizer.prototype.addLayers_ = function(root) {
 /**
  * Add Cesium objects.
  * @param {Array.<T>} cesiumObjects
- * @param {number} layerId
+ * @param {string} layerId
  * @param {ol.layer.Base} layer
  * @private
  */


### PR DESCRIPTION
This solves one problem we encountered: when adding an image layer with a source which initialization is delayed, the layer is not displayed in Cesium (but it is in OpenLayers).