### PR TITLE
Add ImageWMS sync support

### DIFF
--- a/examples/imageWMS.html
+++ b/examples/imageWMS.html
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE HTML>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="robots" content="index, all" />
+    <title>Image WMS example</title>
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css">
+  </head>
+  <body>
+    <div id="map" style="width:600px;height:400px;"></div>
+    <input type="button" value="Enable/disable" onclick="javascript:ol3d.setEnabled(!ol3d.getEnabled())" />
+
+    <script src="inject_ol_cesium.js"></script>
+    <script src="imageWMS.js"></script>
+  </body>
+</html>

--- a/examples/imageWMS.js
+++ b/examples/imageWMS.js
@@ -1,0 +1,57 @@
+/* eslint googshift/valid-provide-and-module: 0 */
+
+goog.provide('examples.main');
+
+goog.require('olcs.OLCesium');
+goog.require('ol.View');
+goog.require('ol.control');
+goog.require('ol.source.ImageWMS');
+goog.require('ol.source.OSM');
+goog.require('ol.layer.Image');
+goog.require('ol.layer.Tile');
+goog.require('ol.Map');
+
+const imageWMSSource = new ol.source.ImageWMS({
+  url: 'https://demo.boundlessgeo.com/geoserver/wms',
+  params: {'LAYERS': 'topp:states'},
+  ratio: 1
+});
+
+const ol2d = new ol.Map({
+  layers: [
+    new ol.layer.Tile({
+      source: new ol.source.OSM()
+    }),
+    new ol.layer.Image({
+      extent: [-13884991, 2870341, -7455066, 6338219],
+      source: imageWMSSource
+    })
+  ],
+  controls: ol.control.defaults({
+    attributionOptions: /** @type {olx.control.AttributionOptions} */ ({
+      collapsible: false
+    })
+  }),
+  target: 'map',
+  view: new ol.View({
+    center: [-10967567.978507737, 4204193.972847062],
+    zoom: 3
+  })
+});
+
+const ol3d = new olcs.OLCesium({
+  map: ol2d,
+  time() {
+    return Cesium.JulianDate.now();
+  }
+});
+const scene = ol3d.getCesiumScene();
+const terrainProvider = new Cesium.CesiumTerrainProvider({
+  url: '//assets.agi.com/stk-terrain/world',
+  requestVertexNormals: true
+});
+scene.terrainProvider = terrainProvider;
+ol3d.setEnabled(true);
+
+
+

--- a/src/olcs/core.js
+++ b/src/olcs/core.js
@@ -3,8 +3,12 @@ goog.require('ol.easing');
 
 goog.require('goog.asserts');
 goog.require('ol.layer.Tile');
+goog.require('ol.layer.Image');
 goog.require('ol.proj');
+goog.require('ol.source.Image');
+goog.require('ol.source.ImageWMS');
 goog.require('ol.source.TileImage');
+goog.require('ol.source.TileWMS');
 goog.require('olcs.core.OLImageryProvider');
 
 
@@ -361,13 +365,28 @@ olcs.core.extentToRectangle = function(extent, projection) {
  * @api
  */
 olcs.core.tileLayerToImageryLayer = function(olLayer, viewProj) {
-  if (!(olLayer instanceof ol.layer.Tile)) {
+
+  if (!(olLayer instanceof ol.layer.Tile) && !(olLayer instanceof ol.layer.Image)) {
     return null;
   }
 
   let provider = null;
+  let source = olLayer.getSource();
 
-  const source = olLayer.getSource();
+  // Convert ImageWMS to TileWMS
+  if (source instanceof ol.source.ImageWMS && source.getUrl() &&
+    source.getImageLoadFunction() === ol.source.Image.defaultImageLoadFunction) {
+    source = new ol.source.TileWMS({
+      url: source.getUrl(),
+      params: source.getParams(),
+      attributions: source.getAttributions(),
+      projection: source.getProjection(),
+      logo: source.getLogo(),
+      'olcs.proxy': source.get('olcs.proxy'),
+      'olcs.imagesource': source
+    });
+  }
+
   if (source instanceof ol.source.TileImage) {
     let projection = source.getProjection();
 


### PR DESCRIPTION
Aims to support `ImageWMS` when it is possible. For that, an alternative `TileWMS` source is created from the `ImageWMS` one and is used to create the Cesium `ImageryLayer`.

Support is not possible when ImageWMS
- has no `url`
- use an `ImageLoadFunction`

No ref to original `ImageWMS` source seems to be need, as the event only watch for `TileWMS` state to be `'ready'`.