### PR TITLE
Allow layers from different projection if supported by Cesium

### DIFF
--- a/examples/customProj.html
+++ b/examples/customProj.html
@@ -1,0 +1,18 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE HTML>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="robots" content="index, all" />
+    <title>Custom projection example</title>
+    <link rel="stylesheet" href="../node_modules/openlayers/css/ol.css" type="text/css">
+  </head>
+  <body>
+    <div id="map" style="width:600px;height:400px;"></div>
+    <input type="button" value="Enable/disable" onclick="javascript:ol3d.setEnabled(!ol3d.getEnabled())" />
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.4.4/proj4.js"></script>
+    <script src="inject_ol_cesium.js"></script>
+    <script src="customProj.js"></script>
+  </body>
+</html>

--- a/examples/customProj.js
+++ b/examples/customProj.js
@@ -1,0 +1,73 @@
+/* eslint googshift/valid-provide-and-module: 0 */
+
+goog.provide('examples.customProj');
+
+goog.require('olcs.OLCesium');
+goog.require('ol.View');
+goog.require('ol.source.ImageWMS');
+goog.require('ol.source.OSM');
+goog.require('ol.layer.Image');
+goog.require('ol.layer.Tile');
+goog.require('ol.Map');
+goog.require('ol.proj');
+goog.require('ol.proj.proj4');
+
+if (typeof ol.proj.proj4.get() == 'function') {
+  const epsg21781def = [
+    '+proj=somerc',
+    '+lat_0=46.95240555555556',
+    '+lon_0=7.439583333333333',
+    '+k_0=1',
+    '+x_0=600000',
+    '+y_0=200000',
+    '+ellps=bessel',
+    '+towgs84=674.374,15.056,405.346,0,0,0,0',
+    '+units=m',
+    '+no_defs'
+  ].join(' ');
+  const epsg21781extent = [420000, 30000, 900000, 350000];
+
+  ol.proj.proj4.get().defs('EPSG:21781', epsg21781def);
+  ol.proj.get('EPSG:21781').setExtent(epsg21781extent);
+}
+
+const customProjSource = new ol.source.ImageWMS({
+  attributions: '© <a href="http://www.geo.admin.ch/internet/geoportal/' +
+  'en/home.html">National parks / geo.admin.ch</a>',
+  crossOrigin: 'anonymous',
+  params: {'LAYERS': 'ch.bafu.schutzgebiete-paerke_nationaler_bedeutung'},
+  projection: 'EPSG:21781',
+  url: 'https://wms.geo.admin.ch/'
+});
+
+customProjSource.set('olcs.projection', ol.proj.get('EPSG:3857'));
+
+const ol2d = new ol.Map({
+  layers: [
+    new ol.layer.Tile({
+      source: new ol.source.OSM()
+    }),
+    new ol.layer.Image({
+      source: customProjSource
+    })
+  ],
+  target: 'map',
+  view: new ol.View({
+    center: [860434.6266531206, 6029479.0044273855],
+    zoom: 6
+  })
+});
+
+const ol3d = new olcs.OLCesium({
+  map: ol2d,
+  time() {
+    return Cesium.JulianDate.now();
+  }
+});
+const scene = ol3d.getCesiumScene();
+const terrainProvider = new Cesium.CesiumTerrainProvider({
+  url: '//assets.agi.com/stk-terrain/world',
+  requestVertexNormals: true
+});
+scene.terrainProvider = terrainProvider;
+ol3d.setEnabled(true);

--- a/src/olcs/core/olimageryprovider.js
+++ b/src/olcs/core/olimageryprovider.js
@@ -2,6 +2,7 @@ goog.provide('olcs.core.OLImageryProvider');
 
 goog.require('ol.events');
 goog.require('ol.proj');
+goog.require('olcs.util');
 
 
 
@@ -174,8 +175,7 @@ Object.defineProperties(olcs.core.OLImageryProvider.prototype, {
  */
 olcs.core.OLImageryProvider.prototype.handleSourceChanged_ = function() {
   if (!this.ready_ && this.source_.getState() == 'ready') {
-    const proj = this.source_.getProjection();
-    this.projection_ = proj ? proj : this.fallbackProj_;
+    this.projection_ = olcs.util.getSourceProjection(this.source_) || this.fallbackProj_;
     if (this.projection_ == ol.proj.get('EPSG:4326')) {
       this.tilingScheme_ = new Cesium.GeographicTilingScheme();
     } else if (this.projection_ == ol.proj.get('EPSG:3857')) {

--- a/src/olcs/util.js
+++ b/src/olcs/util.js
@@ -52,3 +52,13 @@ olcs.util.imageRenderingValue = function() {
   return olcs.util.imageRenderingValueResult_ || '';
 };
 
+/**
+ * Return the projection of the source that Cesium should use.
+ *
+ * @param {ol.source.Source} source Source.
+ * @returns {ol.proj.Projection} The projection of the source.
+ */
+olcs.util.getSourceProjection = function(source) {
+  return /** @type {ol.proj.Projection} */ (source.get('olcs.projection'))
+    || source.getProjection();
+};


### PR DESCRIPTION
During raster sync, if the source of the layer has a different projection than the view, layer is ignored.

This PR aims to avoid this limitation. 

- If the source projection is different from the view but still supported by Cesium (`4326`, `3857`) then it is added.
- If it is a custom projection other than the 2 aboves, we check if the source can support Cesium projection via (`olcs.proj.4326` and `olcs.proj.3857` properties) and if yes we create a new source with supported projection to add it to Cesium.