### PR TITLE
Fix source projection retrieval for WMS

### DIFF
--- a/src/olcs/core.js
+++ b/src/olcs/core.js
@@ -394,14 +394,14 @@ olcs.core.tileLayerToImageryLayer = function(olLayer, viewProj) {
   }
 
   if (source instanceof ol.source.TileImage) {
-    let projection = source.getProjection();
+    let projection = olcs.util.getSourceProjection(source);
 
     if (!projection) {
       // if not explicit, assume the same projection as view
       projection = viewProj;
     }
 
-    if (olcs.core.isCesiumProjection(olcs.util.getSourceProjection(source)))  {
+    if (olcs.core.isCesiumProjection(projection))  {
       provider = new olcs.core.OLImageryProvider(source, viewProj);
     }
     // Projection not supported by Cesium


### PR DESCRIPTION
Keep default behavior:

If no projection is defined in the layer via `layer.getSource().getProjection()` or `layer.getSource().get('olcs.projection')`, then use map projection for the layer (that should support it because it is the one used for openlayers).