### PR TITLE
Properly clear billboards on feature remove

### DIFF
--- a/externs/olcsx.js
+++ b/externs/olcsx.js
@@ -81,7 +81,7 @@ olcsx.core = {};
  *  primitives: (!Cesium.PrimitiveCollection),
  *  featureToCesiumMap: (Object.<
  *    number,
- *    !Cesium.Primitive|!Cesium.Billboard>),
+ *    Array<!Cesium.Primitive|!Cesium.Billboard>>),
  *  billboards: (!Cesium.BillboardCollection)
  * }}
  * @api

--- a/src/olcs/featureconverter.js
+++ b/src/olcs/featureconverter.js
@@ -947,7 +947,13 @@ olcs.FeatureConverter.prototype.olFeatureToCesium = function(layer, feature, sty
 
   const proj = context.projection;
   const newBillboardAddedCallback = function(bb) {
-    context.featureToCesiumMap[ol.getUid(feature)] = bb;
+    const featureBb = context.featureToCesiumMap[ol.getUid(feature)];
+    if (featureBb instanceof Array) {
+      featureBb.push(bb);
+    }
+    else {
+      context.featureToCesiumMap[ol.getUid(feature)] = [bb];
+    }
   };
 
   switch (geom.getType()) {

--- a/src/olcs/vectorsynchronizer.js
+++ b/src/olcs/vectorsynchronizer.js
@@ -146,15 +146,16 @@ olcs.VectorSynchronizer.prototype.createSingleLayerCounterparts = function(olLay
   }).bind(this);
 
   const onRemoveFeature = (function(feature) {
-    const geometry = feature.getGeometry();
     const id = ol.getUid(feature);
-    if (!geometry || geometry.getType() == 'Point') {
-      const context = counterpart.context;
-      const bb = context.featureToCesiumMap[id];
+    const context = counterpart.context;
+    const bbs = context.featureToCesiumMap[id];
+    if (bbs) {
       delete context.featureToCesiumMap[id];
-      if (bb instanceof Cesium.Billboard) {
-        context.billboards.remove(bb);
-      }
+      bbs.forEach((bb) => {
+        if (bb instanceof Cesium.Billboard) {
+          context.billboards.remove(bb);
+        }
+      });
     }
     const csPrimitive = featurePrimitiveMap[id];
     delete featurePrimitiveMap[id];


### PR DESCRIPTION
For the meantime, during feature removal, only geometry of type `ol.geom.Point` were removing their corresponding potential billboard (only one cause it's a point).

But ol-cesium also manage multipoint and multi style, for example a `LineString` with a style with a `geometryFunction` returning a `MultiPoint`. In those cases, billboards were not cleared.

So the pool of billboard for a feature is now an array, and the array is cleared whatever the type of the geometry when the feature is removed.