### PR TITLE
Fix credit creation

### DIFF
--- a/Cesium.externs.js
+++ b/Cesium.externs.js
@@ -1805,11 +1805,10 @@ Cesium.Event.prototype.addEventListener = function(listener, opt_scope) {};
 
 /**
  * @constructor
- * @param {string=} opt_text
- * @param {string=} opt_imageUrl
- * @param {string=} opt_link
+ * @param {{text: string}} opt_text
+ * @param {boolean=} opt_show
  */
-Cesium.Credit = function(opt_text, opt_imageUrl, opt_link) {};
+Cesium.Credit = function(opt_text, opt_show) {};
 
 
 /**

--- a/src/olcs/core/olimageryprovider.js
+++ b/src/olcs/core/olimageryprovider.js
@@ -187,8 +187,7 @@ olcs.core.OLImageryProvider.prototype.handleSourceChanged_ = function() {
     }
     this.rectangle_ = this.tilingScheme_.rectangle;
 
-    const credit = olcs.core.OLImageryProvider.createCreditForSource(this.source_);
-    this.credit_ = credit || null;
+    this.credit_ = olcs.core.OLImageryProvider.createCreditForSource(this.source_);
 
     this.ready_ = true;
   }
@@ -215,7 +214,7 @@ olcs.core.OLImageryProvider.createCreditForSource = function(source) {
     });
   }
 
-  return text.length > 0 ? new Cesium.Credit(text, undefined, undefined) : null;
+  return text.length > 0 ? new Cesium.Credit({text}) : null;
 };
 
 


### PR DESCRIPTION
Related to #575.

I tested the examples, notably main is quite strange:
- I do not see the Cesium credits;
- instead there is an empty grey box (from OpenLayers);
- when toggling off then on the 3d, then credits show up (in an OpenLayers div...).

In top of that, Cesium is changing how it handles credits in next version (due next week).