### PR TITLE
Always rely on frameState to create attributions

### DIFF
--- a/examples/bing.html
+++ b/examples/bing.html
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE HTML>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="robots" content="index, all" />
+    <title>Bing example</title>
+    <link rel="stylesheet" href="../node_modules/ol/ol.css" type="text/css">
+  </head>
+  <body>
+    <div id="map" style="width:600px;height:400px;"></div>
+    <input id="enable" type="button" value="Enable/disable" />
+
+    <script src="inject_ol_cesium.js"></script>
+  </body>
+</html>

--- a/examples/bing.js
+++ b/examples/bing.js
@@ -1,0 +1,52 @@
+/**
+ * @module examples.main
+ */
+const exports = {};
+
+import OLCesium from 'olcs/OLCesium.js';
+import olView from 'ol/View.js';
+import {defaults as olControlDefaults} from 'ol/control.js';
+import olBingMaps from 'ol/source/BingMaps.js';
+import olLayerTile from 'ol/layer/Tile.js';
+import olMap from 'ol/Map.js';
+
+const ol2d = new olMap({
+  layers: [
+    new olLayerTile({
+      preload: Infinity,
+      source: new olBingMaps({
+        key: 'As1HiMj1PvLPlqc_gtM7AqZfBL8ZL3VrjaS3zIb22Uvb9WKhuJObROC-qUpa81U5',
+        imagerySet: 'Aerial'
+      })
+    }),
+  ],
+  controls: olControlDefaults({
+    attribution: true,
+    attributionOptions: /** @type {olx.control.AttributionOptions} */ ({
+      collapsible: false
+    })
+  }),
+  target: 'map',
+  view: new olView({
+    center: [-10967567.978507737, 4204193.972847062],
+    zoom: 3
+  })
+});
+
+const ol3d = new OLCesium({
+  map: ol2d,
+  time() {
+    return Cesium.JulianDate.now();
+  }
+});
+const scene = ol3d.getCesiumScene();
+const terrainProvider = new Cesium.CesiumTerrainProvider({
+  url: '//assets.agi.com/stk-terrain/world',
+  requestVertexNormals: true
+});
+scene.terrainProvider = terrainProvider;
+ol3d.setEnabled(true);
+
+document.getElementById('enable').addEventListener('click', () => ol3d.setEnabled(!ol3d.getEnabled()));
+
+export default exports;

--- a/src/olcs/RasterSynchronizer.js
+++ b/src/olcs/RasterSynchronizer.js
@@ -79,7 +79,7 @@ class RasterSynchronizer extends olcsAbstractSynchronizer {
    * @protected
    */
   convertLayerToCesiumImageries(olLayer, viewProj) {
-    const result = olcsCore.tileLayerToImageryLayer(olLayer, viewProj);
+    const result = olcsCore.tileLayerToImageryLayer(this.map, olLayer, viewProj);
     return result ? [result] : null;
   }
 

--- a/src/olcs/core.js
+++ b/src/olcs/core.js
@@ -354,12 +354,13 @@ exports.extentToRectangle = function(extent, projection) {
 /**
  * Creates Cesium.ImageryLayer best corresponding to the given ol.layer.Layer.
  * Only supports raster layers
+ * @param {!ol.Map} olMap
  * @param {!ol.layer.Base} olLayer
  * @param {!ol.proj.Projection} viewProj Projection of the view.
  * @return {?Cesium.ImageryLayer} null if not possible (or supported)
  * @api
  */
-exports.tileLayerToImageryLayer = function(olLayer, viewProj) {
+exports.tileLayerToImageryLayer = function(olMap, olLayer, viewProj) {
 
   if (!(olLayer instanceof olLayerTile) && !(olLayer instanceof olLayerImage)) {
     return null;
@@ -395,7 +396,7 @@ exports.tileLayerToImageryLayer = function(olLayer, viewProj) {
     }
 
     if (exports.isCesiumProjection(projection))  {
-      provider = new olcsCoreOLImageryProvider(source, viewProj);
+      provider = new olcsCoreOLImageryProvider(olMap, source, viewProj);
     }
     // Projection not supported by Cesium
     else {


### PR DESCRIPTION
Some TileSources (TileUTFGrid, TileJSON and BingMaps, to date) define
their `setAttributions` function with a `frameState` argument,
provided by PluggableMap's POSTRENDER event in OpenLayers. With
ol-cesium, OLImageProvider calls `setAttributions` on instantiation,
without any arguments -- which, of course, results in an exception.

In this commit, we've implemented getTileCredits in order to
dynamically generate credits based on what's in the viewport.

An example using Bing (with the same credentials in OpenLayer's
repository) has been added to show the change in action.