### PR TITLE
added circle outline GroundPolyline

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 * Changes
   * Port to OpenLayers 5.0.2.
   * Port to Cesium 1.47.
+  * Improved line & outline support for ground primitives.
 
 # v 2.0 - 2018-05-04
 

--- a/examples/groundvectors.js
+++ b/examples/groundvectors.js
@@ -16,6 +16,8 @@ import olStyleCircle from 'ol/style/Circle.js';
 import olSourceVector from 'ol/source/Vector.js';
 import olFormatGeoJSON from 'ol/format/GeoJSON.js';
 import olLayerVector from 'ol/layer/Vector.js';
+import olFeature from 'ol/Feature';
+import olCircle from 'ol/geom/Circle';
 
 const image = new olStyleCircle({
   radius: 5,
@@ -108,6 +110,10 @@ const vectorLayer = new olLayerVector({
   source: vectorSource,
   style: styleFunction
 });
+
+vectorLayer.getSource().addFeature(new olFeature({
+  geometry: new olCircle([16880133.570042003, -3565441.544459192], 200)
+}));
 
 const map = new olMap({
   layers: [

--- a/src/olcs/FeatureConverter.js
+++ b/src/olcs/FeatureConverter.js
@@ -5,7 +5,7 @@ import olGeomGeometry from 'ol/geom/Geometry.js';
 import olStyleIcon from 'ol/style/Icon.js';
 import olSourceVector from 'ol/source/Vector.js';
 import olSourceCluster from 'ol/source/Cluster.js';
-import {circular} from 'ol/geom/Polygon.js';
+import {circular as olCreateCircularPolygon} from 'ol/geom/Polygon.js';
 import googAsserts from 'goog/asserts.js';
 import * as olBase from 'ol/index.js';
 import * as olEvents from 'ol/events.js';
@@ -322,7 +322,7 @@ exports.prototype.olCircleGeometryToCesium = function(layer, feature, olGeometry
   if (this.getHeightReference(layer, feature, olGeometry) === Cesium.HeightReference.CLAMP_TO_GROUND) {
     const width = this.extractLineWidthFromOlStyle(olStyle);
     if (width) {
-      const circlePolygon = circular(olGeometry.getCenter(), radius);
+      const circlePolygon = olCreateCircularPolygon(olGeometry.getCenter(), radius);
       const positions = olcsCore.ol4326CoordinateArrayToCsCartesians(circlePolygon.getLinearRing(0).getCoordinates());
       if (!Cesium.GroundPolylinePrimitive.isSupported(this.scene)) {
         const color = this.extractColorFromOlStyle(olStyle, true);

--- a/src/olcs/FeatureConverter.js
+++ b/src/olcs/FeatureConverter.js
@@ -5,6 +5,7 @@ import olGeomGeometry from 'ol/geom/Geometry.js';
 import olStyleIcon from 'ol/style/Icon.js';
 import olSourceVector from 'ol/source/Vector.js';
 import olSourceCluster from 'ol/source/Cluster.js';
+import {circular} from 'ol/geom/Polygon.js';
 import googAsserts from 'goog/asserts.js';
 import * as olBase from 'ol/index.js';
 import * as olEvents from 'ol/events.js';
@@ -317,17 +318,46 @@ exports.prototype.olCircleGeometryToCesium = function(layer, feature, olGeometry
     height
   });
 
-  const outlineGeometry = new Cesium.CircleOutlineGeometry({
-    // always update Cesium externs before adding a property
-    center,
-    radius,
-    extrudedHeight: height,
-    height
-  });
+  let outlinePrimitive, outlineGeometry;
+  if (this.getHeightReference(layer, feature, olGeometry) === Cesium.HeightReference.CLAMP_TO_GROUND) {
+    const width = this.extractLineWidthFromOlStyle(olStyle);
+    if (width) {
+      const circlePolygon = circular(olGeometry.getCenter(), radius);
+      const positions = olcsCore.ol4326CoordinateArrayToCsCartesians(circlePolygon.getLinearRing(0).getCoordinates());
+      if (!Cesium.GroundPolylinePrimitive.isSupported(this.scene)) {
+        const color = this.extractColorFromOlStyle(olStyle, true);
+        outlinePrimitive = this.createStackedGroundCorridors(layer, feature, width, color, positions);
+      } else {
+        outlinePrimitive = new Cesium.GroundPolylinePrimitive({
+          geometryInstances: new Cesium.GeometryInstance({
+            geometry: new Cesium.GroundPolylineGeometry({positions, width}),
+          }),
+          appearance: new Cesium.PolylineMaterialAppearance({
+            material: this.olStyleToCesium(feature, olStyle, true),
+          }),
+          classificationType: Cesium.ClassificationType.TERRAIN,
+        });
+        outlinePrimitive.readyPromise.then(() => {
+          this.setReferenceForPicking(layer, feature, outlinePrimitive._primitive);
+        });
+      }
+    }
+  } else {
+    outlineGeometry = new Cesium.CircleOutlineGeometry({
+      // always update Cesium externs before adding a property
+      center,
+      radius,
+      extrudedHeight: height,
+      height
+    });
+  }
 
   const primitives = this.wrapFillAndOutlineGeometries(
       layer, feature, olGeometry, fillGeometry, outlineGeometry, olStyle);
 
+  if (outlinePrimitive) {
+    primitives.add(outlinePrimitive);
+  }
   return this.addTextStyle(layer, feature, olGeometry, olStyle, primitives);
 };
 


### PR DESCRIPTION
Taking the ideas of @ediebold used in #603, I added support for clamped  `ol.geom.Circle` outline geometries.