### PR TITLE
Do not crash when vector layer source is not initialized

### DIFF
--- a/src/olcs/VectorSynchronizer.js
+++ b/src/olcs/VectorSynchronizer.js
@@ -111,6 +111,10 @@ class VectorSynchronizer extends olcsAbstractSynchronizer {
       source = source.getSource();
     }
 
+    if (!source) {
+      return null;
+    }
+
     googAsserts.assertInstanceof(source, olSourceVector);
     googAsserts.assert(this.view);
 


### PR DESCRIPTION
Hello,
I found a problem when vector layer source is not initialized: in our case, we create a layer but the source is created later => the layer has an empty source when ol-cesium tries to create the SingleLayerCounterparts.
Example of code that would fail:
```javascript
const vectorSource = new olSourceVector({features: myFeatures});
const vectorLayer = new olLayerVector({});
setTimeout(() => vectorLayer.setSource(vectorSource), 3000);
const map = new olMap({
  layers: [vectorLayer],
  target: 'map2d'
});
```
On OpenLayers, it does not cause any problem (the layer features appear on the map when the source is updated), but it crashes on ol-cesium.
This will fix it.