### PR TITLE
Export module in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "serve": "cross-env DEV_SERVER=1 TARGET=examples webpack-dev-server --port 3000 --progress --watch --bail --debug"
   },
   "main": "./dist/olcesium.js",
+  "module": "./src/index.library.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/openlayers/ol-cesium.git"


### PR DESCRIPTION
Hello,
For any application using Webpack to build, we should point the `"module"` property (package.json) to the library source instead of its built version.

It also solves a problem that started to occur in ol-cesium 2.2: I got an error "_ol is not defined_" in the browser (I did not investigate further, but seems to be related to the "oldfashioned" library change from the 2.2 version).