### PR TITLE
Fix custom vector styles

### DIFF
--- a/src/olcs/FeatureConverter.js
+++ b/src/olcs/FeatureConverter.js
@@ -1008,7 +1008,7 @@ class FeatureConverter {
     let style = null;
 
     if (featureStyleFunction) {
-      style = featureStyleFunction.call(feature, resolution);
+      style = featureStyleFunction(feature, resolution);
     }
 
     if (!style && fallbackStyleFunction) {


### PR DESCRIPTION
Hi,
This fixes an issue when a feature style is customized through a StyleFunction.
The code:
```
style = featureStyleFunction.call(feature, resolution);
```
does not correctly execute because `call` function requires a context object passed as first argument.
The current context is not needed here, so we just need to call the function with the arguments, as it is done just after with `fallbackStyleFunction`

Thanks.