### PR TITLE
Correctly map icon anchor from IconStyle to Billboard

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Changelog
 
+# v 2.5
+
+* Breaking changes
+  * Icons are now anchored as specified in the OpenLayers style.
+
+* Changes
+  * CanvasPattern and CanvasGradient styles are now handled for polygons.
+
 # v 2.4 - 2018-10-01
 
 * Changes

--- a/examples/icon-position.html
+++ b/examples/icon-position.html
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE HTML>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="robots" content="index, all" />
+    <title>olcesium vectors example</title>
+    <link rel="stylesheet" href="../node_modules/ol/ol.css" type="text/css"></link>
+    <style>.cesium-credit-textContainer { display: inline-block; font-size: 50%; line-height: 100%;}</style>
+  </head>
+  <body>
+    <div id="map2d" style="width:600px;height:400px;float:left;"></div>
+    <div id="map3d" style="width:600px;height:400px;float:left;position:relative;"></div>
+    <div><input id="enable" type="button" value="Enable/disable Cesium" /></div>
+    <div><input type="button" value="Toggle depth test"
+      onclick="javascript:scene.globe.depthTestAgainstTerrain = !scene.globe.depthTestAgainstTerrain; ol3d.getAutoRenderLoop().restartRenderLoop()" /></div>
+    <div><input type="button" value="Toggle clampToGround mode"
+      onclick="javascript:toggleClampToGround(); ol3d.getAutoRenderLoop().restartRenderLoop()" /></div>
+    <div>Icon on the right has default placement: it is centered on the point position.<br />
+         The icon on the left has its anchor on the bottom center</div>
+    <script src="inject_ol_cesium.js"></script>
+  </body>
+</html>

--- a/examples/icon-position.js
+++ b/examples/icon-position.js
@@ -1,0 +1,129 @@
+/**
+ * @module examples.vectors
+ */
+const exports = {};
+import OLCesium from 'olcs/OLCesium.js';
+import olView from 'ol/View.js';
+import {defaults as olControlDefaults} from 'ol/control.js';
+import olSourceOSM from 'ol/source/OSM.js';
+import olLayerTile from 'ol/layer/Tile.js';
+import olStyleText from 'ol/style/Text.js';
+import olStyleIcon from 'ol/style/Icon.js';
+import olStyleStyle from 'ol/style/Style.js';
+import olGeomPoint from 'ol/geom/Point.js';
+import olFeature from 'ol/Feature.js';
+import olStyleStroke from 'ol/style/Stroke.js';
+import {defaults as interactionDefaults} from 'ol/interaction.js';
+import olStyleFill from 'ol/style/Fill.js';
+import olMap from 'ol/Map.js';
+import olSourceVector from 'ol/source/Vector.js';
+import olLayerVector from 'ol/layer/Vector.js';
+import olcsCore from 'olcs/core.js';
+
+
+const icon1Feature = new olFeature({
+  geometry: new olGeomPoint([700000, 200000])
+});
+icon1Feature.setStyle(new olStyleStyle({
+  image: new olStyleIcon(/** @type {olx.style.IconOptions} */ ({
+    anchor: [0.5, 1],
+    src: 'data/icon.png',
+  })),
+  text: new olStyleText({
+    text: 'Icon with anchor on the bottom center',
+    stroke: new olStyleStroke({
+      color: 'black',
+      width: 3
+    }),
+    fill: new olStyleFill({
+      color: 'white'
+    })
+  })
+}));
+
+const icon2Feature = new olFeature({
+  geometry: new olGeomPoint([1000000, 200000])
+});
+icon2Feature.setStyle(new olStyleStyle({
+  image: new olStyleIcon(/** @type {olx.style.IconOptions} */ ({
+    src: 'data/image-static.png'
+  })),
+  text: new olStyleText({
+    text: 'Default positioning',
+    stroke: new olStyleStroke({
+      color: 'black',
+      width: 3
+    }),
+    fill: new olStyleFill({
+      color: 'white'
+    })
+  })
+}));
+
+const vectorSource = new olSourceVector({
+  features: [
+    icon1Feature,
+    icon2Feature
+  ]
+});
+
+const vectorLayer = new olLayerVector({
+  source: vectorSource
+});
+
+const map = new olMap({
+  interactions: interactionDefaults(),
+  layers: [
+    new olLayerTile({
+      source: new olSourceOSM()
+    }),
+    vectorLayer
+  ],
+  target: 'map2d',
+  controls: olControlDefaults({
+    attributionOptions: /** @type {olx.control.AttributionOptions} */ ({
+      collapsible: false
+    })
+  }),
+  view: new olView({
+    center: [850000, 200000],
+    zoom: 7
+  })
+});
+
+Cesium.Ion.defaultAccessToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiI0MzAyNzUyYi0zY2QxLTQxZDItODRkOS1hNTA3MDU3ZTBiMDUiLCJpZCI6MjU0MSwiaWF0IjoxNTMzNjI1MTYwfQ.oHn1SUWJa12esu7XUUtEoc1BbEbuZpRocLetw6M6_AA';
+const ol3d = new OLCesium({map, target: 'map3d'});
+const scene = ol3d.getCesiumScene();
+scene.terrainProvider = Cesium.createWorldTerrain();
+ol3d.setEnabled(true);
+
+window['toggleClampToGround'] = function() {
+  let altitudeMode;
+  if (!vectorLayer.get('altitudeMode')) {
+    altitudeMode = 'clampToGround';
+  }
+  vectorLayer.set('altitudeMode', altitudeMode);
+  map.removeLayer(vectorLayer);
+  map.addLayer(vectorLayer);
+};
+
+window['ol3d'] = ol3d;
+window['scene'] = scene;
+document.getElementById('enable').addEventListener('click', () => ol3d.setEnabled(!ol3d.getEnabled()));
+
+ol3d.enableAutoRenderLoop();
+
+
+// Tilt camera
+const camera = scene.camera;
+const pivot = olcsCore.pickBottomPoint(scene);
+if (pivot) {
+  const options = {};
+  const transform = Cesium.Matrix4.fromTranslation(pivot);
+  const axis = camera.right;
+  const rotateAroundAxis = olcsCore.rotateAroundAxis;
+  rotateAroundAxis(camera, -Math.PI / 4, axis, transform, options);
+}
+
+
+export default exports;

--- a/src/olcs/FeatureConverter.js
+++ b/src/olcs/FeatureConverter.js
@@ -706,9 +706,16 @@ class FeatureConverter {
         color,
         scale: imageStyle.getScale(),
         heightReference,
-        verticalOrigin: Cesium.VerticalOrigin.BOTTOM,
         position
       });
+
+      if (imageStyle instanceof olStyleIcon) {
+        bbOptions.pixelOffset = new Cesium.Cartesian2(
+            image.width / 2 - imageStyle.getAnchor()[0],
+            image.height / 2 - imageStyle.getAnchor()[1]
+        );
+      }
+
       const bb = this.csAddBillboard(billboards, bbOptions, layer, feature, olGeometry, style);
       if (opt_newBillboardCallback) {
         opt_newBillboardCallback(bb);


### PR DESCRIPTION
Hello,
By default in ol-cesium, icons are positioned differently in 2D (default is the anchor in the center of the icon) and in 3D (icon is bottom-aligned).
This fixes this problem as it calculates Cesium Billboard pixel offset from OpenLayer anchor position.