### PR TITLE
CanvasPattern and CanvasGradient as polygon surface style

### DIFF
--- a/examples/fillstyle.html
+++ b/examples/fillstyle.html
@@ -13,6 +13,8 @@
     <div id="map2d" style="width:600px;height:400px;float:left;"></div>
     <div id="map3d" style="width:600px;height:400px;float:left;position:relative;"></div>
     <div><input id="enable" type="button" value="Enable/disable Cesium" /></div>
+    <div><input type="button" value="Toggle clampToGround mode"
+      onclick="javascript:toggleClampToGround(); ol3d.getAutoRenderLoop().restartRenderLoop()" /></div>
     <script src="inject_ol_cesium.js"></script>
   </body>
 </html>

--- a/examples/fillstyle.html
+++ b/examples/fillstyle.html
@@ -1,5 +1,4 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<?xml version='1.0' encoding='UTF-8'?>
 <!DOCTYPE HTML>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
   <head>

--- a/examples/fillstyle.html
+++ b/examples/fillstyle.html
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE HTML>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="robots" content="index, all" />
+    <title>olcesium vectors example</title>
+    <link rel="stylesheet" href="../node_modules/ol/ol.css" type="text/css"></link>
+    <style>.cesium-credit-textContainer { display: inline-block; font-size: 50%; line-height: 100%;}</style>
+  </head>
+  <body>
+    <div id="map2d" style="width:600px;height:400px;float:left;"></div>
+    <div id="map3d" style="width:600px;height:400px;float:left;position:relative;"></div>
+    <div><input id="enable" type="button" value="Enable/disable Cesium" /></div>
+    <script src="inject_ol_cesium.js"></script>
+  </body>
+</html>
+

--- a/examples/fillstyle.js
+++ b/examples/fillstyle.js
@@ -87,5 +87,14 @@ document.getElementById('enable').addEventListener('click', () => ol3d.setEnable
 
 ol3d.enableAutoRenderLoop();
 
+window['toggleClampToGround'] = function() {
+  let altitudeMode;
+  if (!vectorLayer.get('altitudeMode')) {
+    altitudeMode = 'clampToGround';
+  }
+  vectorLayer.set('altitudeMode', altitudeMode);
+  map.removeLayer(vectorLayer);
+  map.addLayer(vectorLayer);
+};
 
 export default exports;

--- a/examples/fillstyle.js
+++ b/examples/fillstyle.js
@@ -1,0 +1,91 @@
+/**
+ * @module examples.vectors
+ */
+const exports = {};
+import OLCesium from 'olcs/OLCesium.js';
+import olView from 'ol/View.js';
+import {defaults as olControlDefaults} from 'ol/control.js';
+import olSourceOSM from 'ol/source/OSM.js';
+import olLayerTile from 'ol/layer/Tile.js';
+import olStyleStyle from 'ol/style/Style.js';
+import olFeature from 'ol/Feature.js';
+import olStyleStroke from 'ol/style/Stroke.js';
+import {defaults as interactionDefaults} from 'ol/interaction.js';
+import olStyleFill from 'ol/style/Fill.js';
+import olMap from 'ol/Map.js';
+import olSourceVector from 'ol/source/Vector.js';
+import olGeomPolygon from 'ol/geom/Polygon.js';
+import olLayerVector from 'ol/layer/Vector.js';
+
+
+
+const vectorSource = new olSourceVector({
+  features: []
+});
+
+const vectorLayer = new olLayerVector({
+  source: vectorSource
+});
+
+const image = new Image();
+image.onload = () => {
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+  canvas.width = 32;
+  canvas.height = 48;
+  ctx.drawImage(image, 0, 0, canvas.width, canvas.height);
+  const canvas2 = document.createElement('canvas');
+  const ctx2 = canvas2.getContext('2d');
+
+  const polygonFeature = new olFeature({
+    geometry: new olGeomPolygon([[[-3e6, 0], [-3e6, 2e6], [-1e6, 2e6], [-1e6, 0], [-3e6, 0]]])
+  });
+  polygonFeature.setStyle(new olStyleStyle({
+    stroke: new olStyleStroke({
+      color: 'green',
+      lineDash: [4],
+      width: 3
+    }),
+    fill: new olStyleFill({
+      color: ctx2.createPattern(canvas, 'repeat')
+    })
+  }));
+  vectorSource.addFeature(polygonFeature);
+};
+image.src = 'data/icon.png';
+
+
+const map = new olMap({
+  interactions: interactionDefaults(),
+  layers: [
+    new olLayerTile({
+      source: new olSourceOSM()
+    }),
+    vectorLayer
+  ],
+  target: 'map2d',
+  controls: olControlDefaults({
+    attributionOptions: /** @type {olx.control.AttributionOptions} */ ({
+      collapsible: false
+    })
+  }),
+  view: new olView({
+    center: [-2e6, 1e6],
+    zoom: 4
+  })
+});
+
+Cesium.Ion.defaultAccessToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiI0MzAyNzUyYi0zY2QxLTQxZDItODRkOS1hNTA3MDU3ZTBiMDUiLCJpZCI6MjU0MSwiaWF0IjoxNTMzNjI1MTYwfQ.oHn1SUWJa12esu7XUUtEoc1BbEbuZpRocLetw6M6_AA';
+const ol3d = new OLCesium({map, target: 'map3d'});
+const scene = ol3d.getCesiumScene();
+scene.terrainProvider = Cesium.createWorldTerrain();
+ol3d.setEnabled(true);
+
+window['ol3d'] = ol3d;
+window['scene'] = scene;
+document.getElementById('enable').addEventListener('click', () => ol3d.setEnabled(!ol3d.getEnabled()));
+
+ol3d.enableAutoRenderLoop();
+
+
+export default exports;

--- a/src/olcs/FeatureConverter.js
+++ b/src/olcs/FeatureConverter.js
@@ -101,7 +101,7 @@ class FeatureConverter {
       if (color) {
         instance.attributes = {
           color: Cesium.ColorGeometryInstanceAttribute.fromColor(color)
-        }
+        };
       }
       return instance;
     };

--- a/src/olcs/core.js
+++ b/src/olcs/core.js
@@ -543,6 +543,16 @@ exports.convertColorToCesium = function(olColor) {
     );
   } else if (typeof olColor == 'string') {
     return Cesium.Color.fromCssColorString(olColor);
+  } else if (olColor instanceof CanvasPattern || olColor instanceof CanvasGradient) {
+    // Render the CanvasPattern/CanvasGradient into a canvas that will be sent to Cesium as material
+    const canvas = document.createElement('canvas');
+    const ctx = canvas.getContext('2d');
+    canvas.width = canvas.height = 256;
+    ctx.fillStyle = olColor;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    return new Cesium.ImageMaterialProperty({
+      image: canvas
+    });
   }
   console.assert(false, 'impossible');
 };


### PR DESCRIPTION
Hi,

When a surface style (`ol.style.Fill`) is defined as a CanvasPattern or CanvasGradient (as defined in the `ColorLike` type) in OpenLayers for a polygon, Cesium fails to display it.  
This change fixes this problem.