### PR TITLE
calculate height for the SynchronizedOverlay using the globe.getHeight function

### DIFF
--- a/src/olcs/SynchronizedOverlay.js
+++ b/src/olcs/SynchronizedOverlay.js
@@ -217,12 +217,19 @@ class SynchronizedOverlay extends olOverlay {
       this.setVisible(false);
       return;
     }
-    let cartesian;
+    let cartesian, height = 0;
     if (position.length === 2) {
-      cartesian = Cesium.Cartesian3.fromDegreesArray(position)[0];
+      const globeHeight = this.scene_.globe.getHeight(Cesium.Cartographic.fromDegrees(position[0], position[1]));
+      if (globeHeight && this.scene_.globe.tilesLoaded) {
+        position[2] = globeHeight;
+      }
+      if (globeHeight) {
+        height = globeHeight;
+      }
     } else {
-      cartesian = Cesium.Cartesian3.fromDegreesArrayHeights(position)[0];
+      height = position[2];
     }
+    cartesian = Cesium.Cartesian3.fromDegrees(position[0], position[1], height);
     const camera = this.scene_.camera;
     const ellipsoidBoundingSphere = new Cesium.BoundingSphere(new Cesium.Cartesian3(), 6356752);
     const occluder = new Cesium.Occluder(ellipsoidBoundingSphere, camera.position);

--- a/src/olcs/SynchronizedOverlay.js
+++ b/src/olcs/SynchronizedOverlay.js
@@ -217,7 +217,7 @@ class SynchronizedOverlay extends olOverlay {
       this.setVisible(false);
       return;
     }
-    let cartesian, height = 0;
+    let height = 0;
     if (position.length === 2) {
       const globeHeight = this.scene_.globe.getHeight(Cesium.Cartographic.fromDegrees(position[0], position[1]));
       if (globeHeight && this.scene_.globe.tilesLoaded) {
@@ -229,7 +229,7 @@ class SynchronizedOverlay extends olOverlay {
     } else {
       height = position[2];
     }
-    cartesian = Cesium.Cartesian3.fromDegrees(position[0], position[1], height);
+    const cartesian = Cesium.Cartesian3.fromDegrees(position[0], position[1], height);
     const camera = this.scene_.camera;
     const ellipsoidBoundingSphere = new Cesium.BoundingSphere(new Cesium.Cartesian3(), 6356752);
     const occluder = new Cesium.Occluder(ellipsoidBoundingSphere, camera.position);


### PR DESCRIPTION
when cesium is configured with a terrain, the synchronized overlay with height 0 seems to be under the terrain, and changes the position depending on the viewpoint. 

This pull request fixes the problem and requests the height from the globe 