### PR TITLE
fix overlaysynchronizer 

### DIFF
--- a/src/olcs/OverlaySynchronizer.js
+++ b/src/olcs/OverlaySynchronizer.js
@@ -102,7 +102,7 @@ class OverlaySynchronizer {
   * @api
   */
   addOverlays() {
-    this.overlays_.forEach((overlay) => { this.addOverlay(); });
+    this.overlays_.forEach((overlay) => { this.addOverlay(overlay); });
   }
 
   /**


### PR DESCRIPTION
Hi, 
during the ES6 Module updates this bug happend, but it only failed for overlays created before the synchronizer has been updated, so it didn't show in the overlay example.

This fixed the addOverlay function