### PR TITLE
fix: update Webpack

### DIFF
--- a/buildtools/webpack.prod.js
+++ b/buildtools/webpack.prod.js
@@ -1,5 +1,5 @@
 const webpack = require('webpack');
-const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const TerserPlugin = require('terser-webpack-plugin');
 
 module.exports = {
   mode: 'production',
@@ -11,8 +11,8 @@ module.exports = {
   ],
   optimization: {
     minimizer: [
-      new UglifyJsPlugin({
-        uglifyOptions: {
+      new TerserPlugin({
+        terserOptions: {
           compress: {
             drop_console: true
           }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ol": "5.3.0",
     "proj4": "2.4.4",
     "temp": "0.8.3",
-    "webpack": "^4.20.2",
+    "webpack": "^4.26.0",
     "webpack-cli": "3.1.1",
     "webpack-dev-server": "3.1.9",
     "webpack-merge": "4.1.4"


### PR DESCRIPTION
Hello,  

The build is failing if uglifyjs Webpack dependency is not installed.  
This change fixes the error when trying to build the library.