### PR TITLE
Synchronize interactions when in 3d mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 * Changes
   * Add new build as UMD
+  * Synchronize map interactions when 3D is enabled
 
 # v 2.5 - 2018-11-09
 

--- a/src/olcs/OLCesium.js
+++ b/src/olcs/OLCesium.js
@@ -496,6 +496,10 @@ class OLCesium {
         });
         interactions.clear();
 
+        this.map_.addInteraction = interaction => this.pausedInteractions_.push(interaction);
+        this.map_.removeInteraction = interaction =>
+          this.pausedInteractions_ = this.pausedInteractions_.filter(i => i !== interaction);
+
         const rootGroup = this.map_.getLayerGroup();
         if (rootGroup.getVisible()) {
           this.hiddenRootGroup_ = rootGroup;
@@ -515,6 +519,10 @@ class OLCesium {
           interactions.push(interaction);
         });
         this.pausedInteractions_.length = 0;
+
+        this.map_.addInteraction = interaction => this.map_.getInteractions().push(interaction);
+        this.map_.removeInteraction = interaction => this.map_.getInteractions().remove(interaction);
+
         this.map_.getOverlayContainer().classList.remove('olcs-hideoverlay');
         this.map_.getOverlayContainerStopEvent().classList.remove('olcs-hideoverlay');
         if (this.hiddenRootGroup_) {


### PR DESCRIPTION
Hello,  

I got an issue in my application when I tried to remove a draw interaction on the map while 3D mode was enabled.  
I can see that when switching to 3D, interactions are temporarily kept into a `pausedInteractions` list then re-applied when switching back to 2D.  
This change allows to update pausedInteractions array when interactions are added or removed from the map when 3D mode is enabled.