### PR TITLE
Fix conversion of icon anchor to pixelOffset

### DIFF
--- a/src/olcs/FeatureConverter.js
+++ b/src/olcs/FeatureConverter.js
@@ -714,13 +714,14 @@ class FeatureConverter {
         color = new Cesium.Color(1.0, 1.0, 1.0, opacity);
       }
 
+      const scale = imageStyle.getScale();
       const heightReference = this.getHeightReference(layer, feature, olGeometry);
 
       const bbOptions = /** @type {Cesium.optionsBillboardCollectionAdd} */ ({
         // always update Cesium externs before adding a property
         image,
         color,
-        scale: imageStyle.getScale(),
+        scale,
         heightReference,
         position
       });
@@ -728,7 +729,7 @@ class FeatureConverter {
       if (imageStyle instanceof olStyleIcon) {
         const anchor = imageStyle.getAnchor();
         if (anchor) {
-          bbOptions.pixelOffset = new Cesium.Cartesian2(image.width / 2 - anchor[0], image.height / 2 - anchor[1]);
+          bbOptions.pixelOffset = new Cesium.Cartesian2((image.width / 2 - anchor[0]) * scale, (image.height / 2 - anchor[1]) * scale);
         }
       }
 


### PR DESCRIPTION
In Cesium the offset of an entity is specified in pixels from it's center by
default. Openlayers uses the top left position as origin.
While the origin is already converted since #653, this does not consider any
scaling of the image that happens in Cesium at a later stage through the scale
parameter. With a scale < 1 this can result in images that are off by multiple
times their own size.

Multiplying the pixel offset with the scale of the image resolves the issue.


The icon-position example can be used to demonstrate this issue when a scale
parameter is added to the first icon.
```
diff --git a/examples/icon-position.js b/examples/icon-position.js
index 62fb17a..362e42b 100644
--- a/examples/icon-position.js
+++ b/examples/icon-position.js
@@ -28,6 +28,7 @@ icon1Feature.setStyle(new olStyleStyle({
   image: new olStyleIcon(/** @type {olx.style.IconOptions} */ ({
     anchor: [0.5, 1],
     src: 'data/icon.png',
+    scale: 0.2,
   })),
   text: new olStyleText({
     text: 'Icon with anchor on the bottom center',
```

Before:
<img width="1202" alt="image" src="https://user-images.githubusercontent.com/1117666/65078559-89698e80-d99d-11e9-86f3-90f24ed0f9ab.png">

After:
<img width="1201" alt="image" src="https://user-images.githubusercontent.com/1117666/65078762-fa10ab00-d99d-11e9-8ae4-cc3e555cf953.png">
