### PR TITLE
Includes custom options from feature into billboard generation

### DIFF
--- a/src/olcs/FeatureConverter.js
+++ b/src/olcs/FeatureConverter.js
@@ -726,6 +726,9 @@ class FeatureConverter {
         position
       });
 
+      // merge in cesium options from openlayers feature
+      Object.assign(bbOptions, feature.get('cesiumOptions'));
+
       if (imageStyle instanceof olStyleIcon) {
         const anchor = imageStyle.getAnchor();
         if (anchor) {


### PR DESCRIPTION
Wondering if there would be any interest in a way to provide more flexibility in generating billboards through ol-cesium. This is more of a jumping off point from a coding perspective. My goal was to be able to provide cesium specific options for the billboard generation.

A feature could now include the key `bbOptions` where you could provide members available to the [billboards](https://cesium.com/docs/cesiumjs-ref-doc/Billboard.html).

```javascript
feature.bbOptions = {
  scaleByDistance: new Cesium.NearFarScalar(1.5e4, 1, 8.0e5, 0.0),
  pixelOffsetScaleByDistance: new Cesium.NearFarScalar(1.5e4, 1, 8.0e5, 0)
}
```