### PR TITLE
Compare projections by code

### DIFF
--- a/src/olcs/core.js
+++ b/src/olcs/core.js
@@ -595,7 +595,7 @@ exports.olGeometryCloneTo4326 = function(geometry, projection) {
 
   const proj4326 = getProjection('EPSG:4326');
   const proj = getProjection(projection);
-  if (proj !== proj4326) {
+  if (proj.getCode() !== proj4326.getCode()) {
     const properties = geometry.getProperties();
     geometry = geometry.clone();
     geometry.transform(proj, proj4326);
@@ -753,8 +753,8 @@ exports.normalizeView = function(view, angle = 0) {
  * @returns {boolean} Whether it's managed by Cesium.
  */
 exports.isCesiumProjection = function(projection) {
-  const is3857 = projection === getProjection('EPSG:3857');
-  const is4326 = projection === getProjection('EPSG:4326');
+  const is3857 = projection.getCode() === 'EPSG:3857';
+  const is4326 = projection.getCode() === 'EPSG:4326';
   return is3857 || is4326;
 };
 

--- a/src/olcs/core/OLImageryProvider.js
+++ b/src/olcs/core/OLImageryProvider.js
@@ -1,7 +1,6 @@
 /**
  * @module olcs.core.OLImageryProvider
  */
-import {get as getProjection} from 'ol/proj.js';
 import olcsUtil from '../util.js';
 import {Tile as TileSource} from 'ol/source.js';
 import {attributionsFunctionToCredits} from '../core.js';
@@ -124,11 +123,11 @@ class OLImageryProvider /* should not extend Cesium.ImageryProvider */ {
         });
       }
 
-      if (this.projection_ == getProjection('EPSG:4326')) {
+      if (this.projection_.getCode() === 'EPSG:4326') {
         // Cesium zoom level 0 is OpenLayers zoom level 1 for layer in EPSG:4326 with a single tile on level 0
         this.shouldRequestNextLevel = options.numberOfLevelZeroTilesX === 1 && options.numberOfLevelZeroTilesY === 1;
         this.tilingScheme_ = new Cesium.GeographicTilingScheme(options);
-      } else if (this.projection_ == getProjection('EPSG:3857')) {
+      } else if (this.projection_.getCode() === 'EPSG:3857') {
         this.shouldRequestNextLevel = false;
         this.tilingScheme_ = new Cesium.WebMercatorTilingScheme(options);
       } else {


### PR DESCRIPTION
We are maintaining layers in our NgRx Store as part of the application state. Therefore we need to deep copy the layers including the projections when updating the state. Comparing projection objects therefore does not work in our case and we would be happy if the projection comparison could be switched to comparing them by their code.