### PR TITLE
Fix #998 - ol layer vectorImage is not rendered

### DIFF
--- a/examples/vectors.html
+++ b/examples/vectors.html
@@ -18,6 +18,8 @@
       onclick="javascript:toggleStyle()" /></div>
     <div><input type="button" value="Add/remove one vector layer"
       onclick="javascript:addOrRemoveOneVectorLayer()" /></div>
+    <div><input type="button" value="Add/remove one vector image layer"
+      onclick="javascript:addOrRemoveOneVectorImageLayer()" /></div>
     <div><input type="button" value="Add/remove one feature"
       onclick="javascript:addOrRemoveOneFeature()" /></div>
     <div><input type="button" value="Toggle clampToGround mode"

--- a/examples/vectors.js
+++ b/examples/vectors.js
@@ -27,6 +27,7 @@ import olGeomPolygon from 'ol/geom/Polygon.js';
 import olInteractionDragAndDrop from 'ol/interaction/DragAndDrop.js';
 import olGeomMultiPolygon from 'ol/geom/MultiPolygon.js';
 import olLayerVector from 'ol/layer/Vector.js';
+import olLayerVectorImage from 'ol/layer/VectorImage.js';
 import {transform} from 'ol/proj.js';
 import olcsCore from 'olcs/core.js';
 import {OLCS_ION_TOKEN} from './_common.js';
@@ -278,6 +279,11 @@ const vectorLayer = new olLayerVector({
   source: vectorSource
 });
 
+const vectorImageLayer = new olLayerVectorImage({
+  style: styleFunction,
+  source: vectorSource
+});
+
 const vectorSource2 = new olSourceVector({
   features: [iconFeature, textFeature, cervinFeature, ...modelFeatures, cartographicRectangle,
     cartographicRectangle2]
@@ -356,6 +362,17 @@ window['addOrRemoveOneVectorLayer'] = function() {
     map.getLayers().insertAt(1, vectorLayer);
   }
   hasTheVectorLayer = !hasTheVectorLayer;
+};
+
+let hasTheVectorImageLayer = false;
+window['addOrRemoveOneVectorImageLayer'] = function() {
+
+  if (hasTheVectorImageLayer) {
+    map.getLayers().remove(vectorImageLayer);
+  } else {
+    map.getLayers().insertAt(2, vectorImageLayer);
+  }
+  hasTheVectorImageLayer = !hasTheVectorImageLayer;
 };
 
 window['addOrRemoveOneFeature'] = function() {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@mapbox/geojsonhint": "^3.0.1",
     "@types/webpack": "^5.28.0",
     "babel-loader": "8.2.2",
-    "cesium": "^1.81.0",
+    "cesium": ">=1.81.0 <=1.97.0",
     "copy-webpack-plugin": "^9.0.0",
     "cross-env": "7.0.3",
     "eslint": "^7.26.0",

--- a/src/olcs/VectorSynchronizer.js
+++ b/src/olcs/VectorSynchronizer.js
@@ -10,6 +10,7 @@ import olLayerVector from 'ol/layer/Vector.js';
 import olLayerVectorTile from 'ol/layer/VectorTile.js';
 import olcsAbstractSynchronizer from './AbstractSynchronizer.js';
 import olcsFeatureConverter from './FeatureConverter.js';
+import olLayerVectorImage from 'ol/layer/VectorImage.js';
 
 class VectorSynchronizer extends olcsAbstractSynchronizer {
   /**
@@ -99,8 +100,16 @@ class VectorSynchronizer extends olcsAbstractSynchronizer {
    * @inheritDoc
    */
   createSingleLayerCounterparts(olLayerWithParents) {
-    const olLayer = olLayerWithParents.layer;
-    if (!(olLayer instanceof olLayerVector) || olLayer instanceof olLayerVectorTile) {
+    let olLayer = olLayerWithParents.layer;
+
+    if(olLayerWithParents.layer instanceof olLayerVectorImage){
+      let convertedVectorLayer = new olLayerVector({source: null});
+      convertedVectorLayer.setStyle(olLayerWithParents.layer.getStyle())
+      convertedVectorLayer.setSource(olLayerWithParents.layer.getSource())
+      olLayer = convertedVectorLayer;
+    }
+    
+    if (!(olLayer instanceof olLayerVector) || olLayer instanceof olLayerVectorTile  || olLayer instanceof olLayerVectorImage) {
       return null;
     }
     console.assert(olLayer instanceof olLayerLayer);


### PR DESCRIPTION
#998 simple fix for the issue 998 like discussed with @gberaudo 

Warning: as the current latest cesium version 1.98.0 is breaking the whole ol-cesium library this commit limits the cesium version to 1.97.0