### PR TITLE
perf(text-offset): Unidirectional offset

### DIFF
--- a/src/olcs/FeatureConverter.js
+++ b/src/olcs/FeatureConverter.js
@@ -963,7 +963,7 @@ class FeatureConverter {
 
     const offsetX = style.getOffsetX();
     const offsetY = style.getOffsetY();
-    if (offsetX != 0 && offsetY != 0) {
+    if (offsetX != 0 || offsetY != 0) {
       const offset = new Cesium.Cartesian2(offsetX, offsetY);
       options.pixelOffset = offset;
     }


### PR DESCRIPTION
There is an OpenLayers vector layer `style` that has both `image` and `text` attributes, and the text cannot overlap with the image. So, it is necessary to set a one-way `offsetY` for the text. However, when synchronizing to OLCesium, the corresponding `Cesium.Label` instance was not offset. Therefore, I adjusted the relevant code for the offset attribute to support one-way offset for the text.