### PR TITLE
perf(overlay): delete duplicated code.

### DIFF
--- a/src/olcs/SynchronizedOverlay.js
+++ b/src/olcs/SynchronizedOverlay.js
@@ -74,7 +74,6 @@ class SynchronizedOverlay extends olOverlay {
     this.listenerKeys_ = [];
     // synchronize our Overlay with the parent Overlay
     const setPropertyFromEvent = event => this.setPropertyFromEvent_(event);
-    this.listenerKeys_.push(this.parent_.on('change:position', setPropertyFromEvent));
     this.listenerKeys_.push(this.parent_.on('change:element', setPropertyFromEvent));
     this.listenerKeys_.push(this.parent_.on('change:offset', setPropertyFromEvent));
     this.listenerKeys_.push(this.parent_.on('change:position', setPropertyFromEvent));


### PR DESCRIPTION
When I was looking at the source code, I found that the registration event in SynchronizedOverlay was duplicated, and I think it should be removable.
![position](https://github.com/openlayers/ol-cesium/assets/49650943/81b74018-6cec-4765-bcdb-ad0ec799b55e)
