### PR TITLE
Forbid renovate to automatically update minor ol and Cesium

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,10 @@
     "automerge": true
   },
   "packageRules": [{
+    "matchPackagePrefixes": ["ol", "cesium"],
+    "matchUpdateTypes": ["minor"],
+    "enabled": false
+  }, {
     "matchUpdateTypes": ["minor", "patch"],
     "groupName": "all patch and minor versions"
   }]


### PR DESCRIPTION
We should validate these manually.