### PR TITLE
Simplify scaling system example

### DIFF
--- a/examples/print.html
+++ b/examples/print.html
@@ -16,7 +16,7 @@
       <option value="portrait">portrait</option>
       <option value="landscape">landscape</option>
     </select>
-    <select id="printScale">
+    <select id="resolutionScale">
       <option value="1">1</option>
       <option value="1.5">1.5</option>
       <option value="2">2</option>

--- a/examples/print.js
+++ b/examples/print.js
@@ -41,7 +41,7 @@ ol3d.setEnabled(true);
 
 
 document.getElementById('enable').addEventListener('click', () => ol3d.setEnabled(!ol3d.getEnabled()));
-document.getElementById('printScale').addEventListener('change', evt => scaleGlobe(Number.parseFloat(evt.target.value)));
+document.getElementById('resolutionScale').addEventListener('change', evt => ol3d.setResolutionScale(Number.parseFloat(evt.target.value)));
 
 function scalingOptions() {
   const printValue = document.querySelector('#printValue').value;
@@ -55,19 +55,6 @@ function scalingOptions() {
   }
 }
 autoDrawMask(scene, () => scalingOptions().scaling);
-
-function scaleGlobe(value) {
-  /**
-   * @type {HTMLCanvasElement}
-   */
-  const canvas = scene.canvas;
-  const currentScale = canvas.width / canvas.clientWidth;
-  if (Math.abs(currentScale - value) < 0.01) {
-    return;
-  }
-  canvas.width = canvas.clientWidth * value;
-  canvas.height = canvas.clientHeight * value;
-}
 
 window['takeScreenshot'] = async function() {
   const r = scalingOptions();


### PR DESCRIPTION
We already have a scaling system. So the example was changed to use it.
Ideally we would use the https://cesium.com/learn/cesiumjs/ref-doc/CesiumWidget.html?classFilter=widge#resolutionScale property, see #1137.