### PR TITLE
Minimal versions are now OL 7 and CesiumJS > 1.90

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,12 +1,17 @@
 # Changelog
 
-# v 2.18 - 2023-01-29
+## v 2.19
+
+* Breaking changes
+  * Bump minimal supported version of OL and CesiumJS and remove compatibility code
+
+## v 2.18 - 2023-01-29
 
 * Breaking changes
   * Remove deprecated oldfashioned build
   * Remove UMD build
 
-# v 2.17 - 2023-01-15
+## v 2.17 - 2023-01-15
 
 * Breaking changes
   * Remove olcsListen wrapper. Use observable.on(type, listener) instead
@@ -27,25 +32,25 @@
   * The export `window.olcs`is deprecatd and will be removed in 2.18.
   * If you have any comment regarding these changes reach to us.
 
-# v 2.16.1 - 2023-12-21
+## v 2.16.1 - 2023-12-21
 
 * Changed
   * Port to OpenLayers 8.2
   * Port to Cesium 1.112
   * Increased camera synchronization precision
 
-# v 2.16 - 2023-09-03
+## v 2.16 - 2023-09-03
 
 * Changes
   * Port to OpenLayers 8
   * Port to Cesium 1.109
 
-# v 2.15.2 - 2023-08-28
+## v 2.15.2 - 2023-08-28
 
 * Changes
   * Rewrite .ts and empty extensions to .js in olcs package
 
-# v 2.15.1 - 2023-08-24
+## v 2.15.1 - 2023-08-24
 
 * Changes
   * Ensure published olcs package only contains javascript (no typescript)
@@ -56,13 +61,13 @@
 * Deprecation
   * computeRectangle and RectangleOutput should now be imported from printUtils
 
-# v 2.15 - 2023-07-26
+## v 2.15 - 2023-07-26
 
 * Changes
   * Add function to grab a screenshot from rendered Cesium globe (client side printing)
   * Port to OL 7.4 and CesiumJS 1.107
 
-# v 2.14.0 - 2023-04-26
+## v 2.14.0 - 2023-04-26
 
 * Breaking changes
   * Use named exports
@@ -70,7 +75,7 @@
 * Changes
   * port to CesiumJS 1.104 and OL 7.3
 
-# v 2.13 - 2021-05-20
+## v 2.13 - 2021-05-20
 
 * Changes
   * Port to CesiumJS 1.81
@@ -78,7 +83,7 @@
   * Copy canvas image when cloning overlay
   * Use tile fonction in MVT imagery provider (handle minus, ...)
 
-# v 2.12 - 2021-01-18
+## v 2.12 - 2021-01-18
 
 * Changes
   * Delete the obsolete plugins directory.
@@ -88,63 +93,63 @@
   * Update to CesiumJS 1.77 and OpenLayers 6.5
   * Expose the resolution from/to distance functions in core
 
-# v 2.11.3 - 2020-09-01
+## v 2.11.3 - 2020-09-01
 
 * Changes
   * Port to OpenLayers 6.4, fix grabbing issue.
 
-# v 2.11.1 - 2020-08-04
+## v 2.11.1 - 2020-08-04
 
 * Changes
   * Remove wrong pixelSize param from getPixelDimensions function
 
-# v 2.11 - 2020-08-04
+## v 2.11 - 2020-08-04
 
 * Changes
   * Handle some custom matrix size for WMTS
   * Update to Cesium 1.70 and add peer dependencies
   * Add missing 'result' param to getPixelDimensions function
 
-# v 2.10 - 2019-10-10
+## v 2.10 - 2019-10-10
 
 * Changes
   * Add a WMTS example.
   * Port to Cesium 1.62.
   * Port to OpenLayers 6 while staying compatible with OpenLayers 5.
 
-# v 2.9 - 2019-04-05
+## v 2.9 - 2019-04-05
 
 * Changes
   * Port to Cesium 1.56.1.
 
-# v 2.8 - 2019-03-13
+## v 2.8 - 2019-03-13
 
 * Changes
   * Port to Cesium 1.55.
 
-# v 2.7.2 - 2019-02-12
+## v 2.7.2 - 2019-02-12
 
 * Changes
   * Fix a type
 
-# v 2.7.1 - 2019-02-08
+## v 2.7.1 - 2019-02-08
 
 * Changes
   * Fix release
 
-# v 2.7 - 2019-02-08
+## v 2.7 - 2019-02-08
 * Changes
   * Port to Cesium 1.54.
   * Document code using typescript.
 
-# v 2.6 - 2018-12-06
+## v 2.6 - 2018-12-06
 
 * Changes
   * Add new build as UMD.
   * Synchronize map interactions when 3D is enabled.
   * Port to Cesium 1.52.
 
-# v 2.5 - 2018-11-09
+## v 2.5 - 2018-11-09
 
 * Breaking changes
   * Icons are now anchored as specified in the OpenLayers style.
@@ -154,12 +159,12 @@
   * Port to Cesium 1.51.
   * Port to OpenLayers 5.3.0.
 
-# v 2.4 - 2018-10-01
+## v 2.4 - 2018-10-01
 
 * Changes
   * Port to Cesium 1.50.
 
-# v 2.3 - 2018-09-27
+## v 2.3 - 2018-09-27
 
 * Changes
   * Port to OpenLayers 5.2.0.
@@ -167,17 +172,17 @@
   * Improve old fashioned build.
   * Port to Cesium 1.49.
 
-# v 2.2.2 - 2018-08-24
+## v 2.2.2 - 2018-08-24
 
 * Changes
   * Stop using internal OpenLayers functions (see oldfashioned example).
 
-# v 2.2.1 - 2018-08-09
+## v 2.2.1 - 2018-08-09
 
 * Changes
   * Export module in package.json.
 
-# v 2.2 - 2018-08-07
+## v 2.2 - 2018-08-07
 
 * Changes
   * Fix dynamic credits handling and add back a Bing example.
@@ -187,7 +192,7 @@
   * Add an old fashioned example (currently requires a custom build of OpenLayers).
   * Fix synchronization issue when a layer has no initial source.
 
-# v 2.1 - 2018-07-13
+## v 2.1 - 2018-07-13
 
 * Changes
   * Port to OpenLayers 5.0.2.
@@ -195,7 +200,7 @@
   * Improve line and outline support for ground primitives.
   * Switch from old style constructors to ES6 classes.
 
-# v 2.0 - 2018-05-04
+## v 2.0 - 2018-05-04
 
 * Breaking changes
   * Migrate to ES6 modules and abandon the Google Closure Compiler build chain
@@ -206,12 +211,12 @@
     it yourself. This is now similar to Cesium, which has always been a
     dependency provided by the application.
 
-# v 1.37 - 2018-05-02
+## v 1.37 - 2018-05-02
 
 * Changes
   * Port to Cesium 1.45.
 
-# v 1.36 - 2018-04-18
+## v 1.36 - 2018-04-18
 
 * Changes
   * Rework the autorenderloop using Cesium RenderMode.
@@ -223,7 +228,7 @@
   * Remove buggy and unused camera.lookAt method.
   * Make the camera.setPosition position the camera in the reference frame.
 
-# v 1.35 - 2018-03-02
+## v 1.35 - 2018-03-02
 
 * Changes
   * Implement stacked ground corridors to improve the rendering of lines on
@@ -234,13 +239,13 @@
     to notably implement arrows along a line clamped on terrain.
   * Port to Cesium 1.43.
 
-# v 1.34 - 2018-01-24
+## v 1.34 - 2018-01-24
 
 * Changes
   * Allow overriding the 3D extent by setting an olcs.extent property in raster layers.
   * Port to OpenLayers 4.6.4 and Cesium 1.41.
 
-# v 1.33 - 2017-12-07
+## v 1.33 - 2017-12-07
 
 * Changes
   * Animate olcs.contrib.Manager#toggle3d.
@@ -253,7 +258,7 @@
   * Add preliminary work for an ES6 package https://www.npmjs.com/package/olcs.
   * Remove management of ol.source.ImageVector. This class is deprecated in OpenLayers 4.6.2.
 
-# v 1.32 - 2017-10-26
+## v 1.32 - 2017-10-26
 
 * Breaking changes
   * Changed AbstractSynchronizer.createSingleLayerCounterparts Plugin API
@@ -273,7 +278,7 @@
   * Add ol.layer.Group synchronization
   * Port to OpenLayers 4.4.2 and Cesium 1.38.
 
-# v 1.31 - 2017-09-06
+## v 1.31 - 2017-09-06
 
 * Changes
   * Port to OpenLayers 4.3.2
@@ -286,13 +291,13 @@
   * Switch to @camptocamp/cesium to allow examples based on vector tiles and
     advanced performance optimizations.
 
-# v 1.30 - 2017-08-03
+## v 1.30 - 2017-08-03
 
 * Changes
   * Port to Cesium 1.36. This fixes blinking of the vector example
     https://github.com/openlayers/ol-cesium/issues/465.
 
-# v 1.29 - 2017-07-12
+## v 1.29 - 2017-07-12
 
 * Changes
   * Port to OpenLayers 4.2.0.
@@ -300,26 +305,26 @@
     it necessary to display the examples using an ES6-capable browser.
   * Port to Cesium 1.35.2.
 
-# v 1.28 - 2017-06-02
+## v 1.28 - 2017-06-02
 
 * Changes
   * Port to Cesium 1.34.
   * Use all the styles defined for a feature.
   * Display geometries coming from style (using getGeometryFunction()).
 
-# v 1.27- 2017-05-04
+## v 1.27- 2017-05-04
 
 * Changes
   * Port to OpenLayers 4.1.1.
   * Port to cesium 1.33.
 
-# v 1.26 - 2017-04-04
+## v 1.26 - 2017-04-04
 
 * Changes
   * WMTS OpenLayers layers are now automatically converted to Cesium layers.
   * Port to Cesium 1.32.
 
-# v 1.25 - 2017-03-28
+## v 1.25 - 2017-03-28
 
 * Breaking changes
   * Stop returning promise from olcs.core.rotateAroundAxis function.
@@ -329,17 +334,17 @@
   * Add example rotate.html about animating rotation of the Cesium globe.
   * Convert source to Ecmascript 6. Continue to output Ecmascript 5.1.
 
-# v 1.24.3 - 2017-02-17
+## v 1.24.3 - 2017-02-17
 
 * Changes
   * For npm.
 
-# v 1.24.2 - 2017-02-17
+## v 1.24.2 - 2017-02-17
 
 * Changes
   * Final rename and publication of the project as a new npm project.
 
-# v 1.24.1 - 2017-02-17
+## v 1.24.1 - 2017-02-17
 
 * Changes
   * Renamed project to OL-Cesium following the renaming of the OpenLayers3 project.
@@ -350,27 +355,27 @@
       make cleanall
     Note that the distributed js file is olcesium.js
 
-# v 1.24 - 2017-02-17
+## v 1.24 - 2017-02-17
 
 * Changes
   * Clamp line to the ground using Corridor geometry (experimental feature).
   * Port to Cesium 1.30.
   * Port to OpenLayers 4.0.1.
 
-# v 1.23 - 2017-01-04
+## v 1.23 - 2017-01-04
 
 * Changes
   * Port to Cesium 1.29.
   * Port to OpenLayers 3.20.0.
 
-# v 1.22 - 2016-12-02
+## v 1.22 - 2016-12-02
 
 * Changes
   * Port to Cesium 1.28.
   * Add OLCesium.setTargetFrameRate to enforce an fps limit for Cesium.
   * Add OLCesium option `time` to control the current time passed to Cesium.
 
-# v 1.21 - 2016-11-02
+## v 1.21 - 2016-11-02
 
 * Changes
   * Add olcs.OLCesium.trackedFeature property to make Cesium automatically track an
@@ -379,26 +384,26 @@
   * Port to OpenLayers 3.19.1.
   * Port to Cesium 1.27.
 
-# v 1.20 - 2016-09-02
+## v 1.20 - 2016-09-02
 
 * Changes
   * Port to Cesium 1.25.
   * Port to OpenLayers 3.18.2.
 
-# v 1.19 - 2016-08-08
+## v 1.19 - 2016-08-08
 
 * Changes
   * Require node 4 or 6.
   * Port to Cesium 1.24.
 
-# v 1.18 - 2016-07-18
+## v 1.18 - 2016-07-18
 
 * Changes
   * Port to Cesium 1.23.
   * Port to OL 3.17.1 (include OL3 typedefs.js and rename some symbols).
   * In examples, use OSM instead of obsolete MapQuest tiles.
 
-# v 1.17 - 2016-06-23
+## v 1.17 - 2016-06-23
 
 * Changes
   * Port to Cesium 1.22.

--- a/package.json
+++ b/package.json
@@ -70,8 +70,8 @@
     }
   ],
   "peerDependencies": {
-    "cesium": ">= 1.62.0",
-    "ol": ">= 6.0.1 || 7 || 8"
+    "cesium": ">= 1.90.0",
+    "ol": ">= 7 || 8"
   },
   "devDependencies": {
     "@babel/parser": "7.23.9",

--- a/src/olcs/MVTImageryProvider.ts
+++ b/src/olcs/MVTImageryProvider.ts
@@ -3,7 +3,6 @@ import Style, {type StyleFunction} from 'ol/style/Style.js';
 import Stroke from 'ol/style/Stroke.js';
 import {toContext} from 'ol/render.js';
 import {get as getProjection} from 'ol/proj.js';
-import {VERSION as OL_VERSION} from 'ol/util.js';
 import LRUCache from 'ol/structs/LRUCache.js';
 import {getForProjection as getTilegridForProjection} from 'ol/tilegrid.js';
 import {createFromTemplates as createTileUrlFunctions} from 'ol/tileurlfunction.js';
@@ -182,30 +181,12 @@ export default class MVTImageryProvider implements ImageryProvider {
   }
 
   readFeaturesFromBuffer(buffer: ArrayBuffer): RenderFeature[] {
-    let options;
-    if (OL_VERSION <= '6.4.4') {
-      // See https://github.com/openlayers/openlayers/pull/11540
-      options = {
-        extent: [0, 0, 4096, 4096],
-        dataProjection: this.projection_,
-        featureProjection: this.projection_
-      };
-    }
-    const features = format.readFeatures(buffer, options) as RenderFeature[];
+    const features = format.readFeatures(buffer) as RenderFeature[];
     const scaleFactor = this.tileWidth / 4096;
     features.forEach((f) => {
       const flatCoordinates = f.getFlatCoordinates();
-      let flip = false;
       for (let i = 0; i < flatCoordinates.length; ++i) {
         flatCoordinates[i] *= scaleFactor;
-        if (flip) {
-          // FIXME: why do we need this now?
-          flatCoordinates[i] = this.tileWidth - flatCoordinates[i];
-        }
-        if (OL_VERSION <= '6.4.4') {
-          // LEGACY
-          flip = !flip;
-        }
       }
     });
 

--- a/src/olcs/contrib/Manager.ts
+++ b/src/olcs/contrib/Manager.ts
@@ -97,16 +97,7 @@ export default class Manager extends Observable {
   instantiateOLCesium(): OLCesium {
     const ol3d = new OLCesium({map: this.map});
     const scene = ol3d.getCesiumScene();
-    // LEGACY
-    if ('createWorldTerrain' in Cesium) {
-      // @ts-ignore
-      const terrainProvider = Cesium.createWorldTerrain();
-      scene.terrainProvider = terrainProvider;
-    } else {
-      // v107+
-      Cesium.createWorldTerrainAsync().then(tp => scene.terrainProvider = tp);
-    }
-
+    Cesium.createWorldTerrainAsync().then(tp => scene.terrainProvider = tp);
     return ol3d;
   }
 

--- a/src/olcs/core/OLImageryProvider.ts
+++ b/src/olcs/core/OLImageryProvider.ts
@@ -1,5 +1,5 @@
 import {getSourceProjection} from '../util';
-import {Tile as TileSource, type TileImage} from 'ol/source.js';
+import {type TileImage} from 'ol/source.js';
 import {attributionsFunctionToCredits} from '../core';
 import type {Map} from 'ol';
 import type {Projection} from 'ol/proj.js';
@@ -12,18 +12,6 @@ export function createEmptyCanvas(): HTMLCanvasElement {
   canvas.height = 1;
   return canvas;
 }
-
-const olUseNewCoordinates = (function() {
-  const tileSource = new TileSource({
-    projection: 'EPSG:3857',
-    wrapX: true
-  });
-  const tileCoord = tileSource.getTileCoordForTileUrlFunction([6, -31, 22]);
-  return tileCoord && tileCoord[1] === 33 && tileCoord[2] === 22;
-  // See b/test/spec/ol/source/tile.test.js
-  // of e9a30c5cb7e3721d9370025fbe5472c322847b35 in OpenLayers repository
-})();
-
 
 export default class OLImageryProvider implements ImageryProvider /* should not extend Cesium.ImageryProvider */ {
   private source_: TileImage;
@@ -281,14 +269,7 @@ export default class OLImageryProvider implements ImageryProvider /* should not 
     const tileUrlFunction = this.source_.getTileUrlFunction();
     if (tileUrlFunction && this.projection_) {
       const z_ = this.shouldRequestNextLevel ? level + 1 : level;
-
-      let y_ = y;
-      if (!olUseNewCoordinates) {
-        // LEGACY
-        // OpenLayers version 3 to 5 tile coordinates increase from bottom to top
-        y_ = -y - 1;
-      }
-      let url = tileUrlFunction.call(this.source_, [z_, x, y_], 1, this.projection_);
+      let url = tileUrlFunction.call(this.source_, [z_, x, y], 1, this.projection_);
       if (this.proxy) {
         url = this.proxy.getURL(url);
       }


### PR DESCRIPTION
One of the best points of OL-Cesium is the large range of supported OL and CesiumJS versions.

It brings lots of flexibility to the application developers.

The code we kept for OL 3,4,5,6 has been removed.
These versions are very old and certainly not used anymore.