### PR TITLE
fix: call `handlePositionChanged` later

### DIFF
--- a/src/olcs/SynchronizedOverlay.ts
+++ b/src/olcs/SynchronizedOverlay.ts
@@ -95,6 +95,7 @@ export default class SynchronizedOverlay extends OLOverlay {
 
     this.handleMapChanged();
     this.handleElementChanged();
+    this.handlePositionChanged();
   }
 
   /**
@@ -176,6 +177,10 @@ export default class SynchronizedOverlay extends OLOverlay {
    * @override
    */
   handlePositionChanged() {
+    // check if constructor has completed
+    if (!this.parent_) {
+      return;
+    }
     // transform position to WGS84
     const position = this.getPosition();
     if (position) {


### PR DESCRIPTION
This avoids the call to `handlePositionChanged` before `this.parent_` has been set. (cause: https://github.com/openlayers/openlayers/blob/73f4636c85e569c6aca36f2ad478b677b7929872/src/ol/Overlay.js#L208)

And calls it again at the end of the constructor.

Fixes #1159 