### PR TITLE
Add export for OverlaySynchronizer in olcs.ts

### DIFF
--- a/src/olcs.ts
+++ b/src/olcs.ts
@@ -4,6 +4,7 @@ export default OLCesium;
 export {default as AbstractSynchronizer} from './olcs/AbstractSynchronizer';
 export {default as RasterSynchronizer} from './olcs/RasterSynchronizer';
 export {default as VectorSynchronizer} from './olcs/VectorSynchronizer';
+export {default as OverlaySynchronizer} from './olcs/OverlaySynchronizer';
 
 export {default as FeatureConverter} from './olcs/FeatureConverter';
 export {default as OLCSCamera} from './olcs/Camera';


### PR DESCRIPTION
I want to pass a custom `createSynchronizers` function to the `OLCesium` constructor with the default `OverlaySynchronizer`, the default `VectorSynchronizer` and a custom `RasterSynchronizer`. I don't know why the `OverlaySynchronizer` isn't exported in the main file, if I import it from `olcs/src/olcs/OverlaySynchronizer`, there are typescript compilation errors, if I add the export to the `olcs.ts` file and import it from there, everything works just fine.