### PR TITLE
Optional synchronisation optimization 3d to 2d

### DIFF
--- a/src/olcs/AutoRenderLoop.ts
+++ b/src/olcs/AutoRenderLoop.ts
@@ -69,6 +69,8 @@ export default class AutoRenderLoop {
   }
 
   notifyRepaintRequired() {
-    this.scene_.requestRender();
+    if (!this.scene_.isDestroyed()) {
+      this.scene_.requestRender();
+    }
   }
 }


### PR DESCRIPTION
This allows to only synchronize from 3d to 2d after the cesium camera stopped moving. This saves a lot of unnecessary overhead, if the 2d map is not visible anyways.
The default behavior is to synchronize continuously as before.