### PR TITLE
Account for asynchronous event generation in ol maps when synchronizing with the 2d map

### DIFF
--- a/src/olcs/Camera.ts
+++ b/src/olcs/Camera.ts
@@ -372,7 +372,8 @@ export default class Camera {
       this.tilt_ = -this.cam_.pitch + Math.PI / 2;
     }
 
-    this.viewUpdateInProgress_ = false;
+    // delay resetting the guard flag to account for asynchronous event generation in ol maps
+    setTimeout(() => this.viewUpdateInProgress_ = false, 1000);
   }
 
   /**


### PR DESCRIPTION
When paning and zooming the 3d map, the pitch (tilt) and the heading of the camera were continuosly adapted by small steps in an unpredictable way. 
There is a guard flag in `Camera.updateView()` which causes the events from the ol map to be ignored, while the ol map is adjusted. Unfortunately the ol map events are generated asynchronously and the guard flag was already reset right at the end of `Camera.updateView()`. This was too early and so events would be handled which should have been ignored.