### PR TITLE
fix: parcel serve target dist directory

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,11 +19,9 @@ browse http://localhost:1234
 ```
 
 ### OLCesium import
-The examples use a compiled version of OLCesium. If you want to use the source code directly you can change the import to '../src/olcs.ts'
 
-```typescript
-import OLCesium from 'olcs'; // or '../src/olcs.ts' for source code
-```
+The examples use a compiled version of OLCesium. If you want to use the source code directly you can define an alias.
+See https://en.parceljs.org/module_resolution.html#aliases
 
 ### The `check` target
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,13 @@ npm start
 browse http://localhost:1234
 ```
 
+### OLCesium import
+The examples use a compiled version of OLCesium. If you want to use the source code directly you can change the import to '../src/olcs.ts'
+
+```typescript
+import OLCesium from 'olcs'; // or '../src/olcs.ts' for source code
+```
+
 ### The `check` target
 
 ```bash

--- a/examples/index.html
+++ b/examples/index.html
@@ -3,27 +3,6 @@
   <head>
     <meta charset="utf-8"/>
     <title>OL-Cesium examples</title>
-    <script type="module">
-      // In local dev, we need to open /examples/index.html for relative paths to be correct
-      // This ugly workaround ensures that.
-      function ensureExamplesUrl(h) {
-        if (h.endsWith('/')) {
-          h += 'index.html';
-        }
-        const split = h.split('/');
-        const lastDir = split.at(-2);
-        if (lastDir !== 'examples') {
-          split.splice(split.length -1, 0, ['examples']);
-          return split.join('/');
-        }
-        return h;
-      }
-      const h = document.location.href.substring(document.location.origin.length);
-      const newH = ensureExamplesUrl(h);
-      if (h !== newH) {
-        document.location.href = newH;
-      }
-    </script>
   </head>
   <body>
 <ul>

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint src buildtools examples",
     "checks": "npm run lint && npm run typecheck",
     "doc": "typedoc --name ol-cesium --excludeExternals --out apidoc --entryPoints src/olcs.ts --tsconfig ./tsconfig.json",
-    "start": "parcel serve --no-autoinstall --target examples",
+    "prestart": "rm -rf dist; mkdir -p dist/examples/node_modules/ol; mkdir -p dist/examples/node_modules/cesium/Build/; cp examples/inject_ol_cesium.js dist/examples/; cp node_modules/ol/ol.css dist/examples/node_modules/ol/; cp -R node_modules/cesium/Build/CesiumUnminified node_modules/cesium/Build/Cesium dist/examples/node_modules/cesium/Build/; cp -R examples/data dist/examples/",
+    "start": "parcel serve ./examples/index.html --dist-dir dist/examples --no-autoinstall",
     "serve-built-examples": "python3 -m http.server --directory dist 12345"
   },
   "targets": {

--- a/package.json
+++ b/package.json
@@ -4,20 +4,20 @@
   "description": "OpenLayers Cesium integration and plugin library",
   "scripts": {
     "test": "node --enable-source-maps --import @swc-node/register/esm-register --test  src/olcs/*.test.ts",
-    "build-examples": "rm -rf dist; parcel build; mkdir -p dist/examples/node_modules/ol; mkdir -p dist/examples/node_modules/cesium/Build/; cp examples/inject_ol_cesium.js dist/examples/; cp node_modules/ol/ol.css dist/examples/node_modules/ol/; cp -R node_modules/cesium/Build/CesiumUnminified node_modules/cesium/Build/Cesium dist/examples/node_modules/cesium/Build/; cp -R examples/data dist/examples/",
+    "build-examples": "rm -rf dist; parcel build --dist-dir dist/examples && npm run copy-static-dist",
     "prepare": "tsc --pretty && node buildtools/fix_paths_recast.js; npm run doc",
     "typecheck": "tsc --pretty --noEmit",
     "lint": "eslint src buildtools examples",
     "checks": "npm run lint && npm run typecheck",
     "doc": "typedoc --name ol-cesium --excludeExternals --out apidoc --entryPoints src/olcs.ts --tsconfig ./tsconfig.json",
-    "prestart": "rm -rf dist; mkdir -p dist/examples/node_modules/ol; mkdir -p dist/examples/node_modules/cesium/Build/; cp examples/inject_ol_cesium.js dist/examples/; cp node_modules/ol/ol.css dist/examples/node_modules/ol/; cp -R node_modules/cesium/Build/CesiumUnminified node_modules/cesium/Build/Cesium dist/examples/node_modules/cesium/Build/; cp -R examples/data dist/examples/",
+    "copy-static-dist": "mkdir -p dist/examples/node_modules/ol; mkdir -p dist/examples/node_modules/cesium/Build/; cp examples/inject_ol_cesium.js dist/examples/; cp node_modules/ol/ol.css dist/examples/node_modules/ol/; cp -R node_modules/cesium/Build/CesiumUnminified node_modules/cesium/Build/Cesium dist/examples/node_modules/cesium/Build/; cp -R examples/data dist/examples/",
+    "prestart": "rm -rf dist; npm run copy-static-dist",
     "start": "parcel serve ./examples/index.html --dist-dir dist/examples --no-autoinstall",
     "serve-built-examples": "python3 -m http.server --directory dist 12345"
   },
   "targets": {
     "examples": {
       "source": "./examples/index.html",
-      "distDir": "dist/examples/",
       "context": "browser",
       "publicUrl": "./",
       "optimize": true,

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "doc": "typedoc --name ol-cesium --excludeExternals --out apidoc --entryPoints src/olcs.ts --tsconfig ./tsconfig.json",
     "copy-static-dist": "mkdir -p dist/examples/node_modules/ol; mkdir -p dist/examples/node_modules/cesium/Build/; cp examples/inject_ol_cesium.js dist/examples/; cp node_modules/ol/ol.css dist/examples/node_modules/ol/; cp -R node_modules/cesium/Build/CesiumUnminified node_modules/cesium/Build/Cesium dist/examples/node_modules/cesium/Build/; cp -R examples/data dist/examples/",
     "prestart": "rm -rf dist; npm run copy-static-dist",
-    "start": "parcel serve ./examples/index.html --dist-dir dist/examples --no-autoinstall",
+    "start": "parcel serve ./examples/index.html --dist-dir dist/examples --no-autoinstall & tsc --watch",
     "serve-built-examples": "python3 -m http.server --directory dist 12345"
   },
   "targets": {


### PR DESCRIPTION
The examples were not working on dev environment after running `npm start` because there is a bug in parcel that is ignoring the distDir attribute in targets for `parcel serve`. I replaced with cli commands and added a `prestart` hook with the commands that were in `build-examples` to add parts that are not compiled by parcel (should we also investigate that?).

bug reports in parcel:
https://github.com/parcel-bundler/parcel/issues/8715
https://github.com/parcel-bundler/parcel/issues/8105
https://github.com/parcel-bundler/parcel/discussions/6778 

Also, should I just remove the targets object from the code? 
