### PR TITLE
Fix missing .js extensions in imports

### DIFF
--- a/src/olcs/OLCesium.ts
+++ b/src/olcs/OLCesium.ts
@@ -1,8 +1,8 @@
 import olGeomPoint from 'ol/geom/Point.js';
 import {supportsImageRenderingPixelated, imageRenderingValue} from './util.js';
-import {ol4326CoordinateToCesiumCartesian} from './core';
+import {ol4326CoordinateToCesiumCartesian} from './core.js';
 import {getTransform, type TransformFunction} from 'ol/proj.js';
-import olcsAutoRenderLoop from './AutoRenderLoop';
+import olcsAutoRenderLoop from './AutoRenderLoop.js';
 import olcsCamera from './Camera.js';
 import olcsRasterSynchronizer from './RasterSynchronizer.js';
 import olcsVectorSynchronizer from './VectorSynchronizer.js';


### PR DESCRIPTION
I can't see any reason why the `.js` is missing on these two imports (as far as I can see they are the only ones), and the fact they are missing is causing webpack to choke in a downstream project.