### PR TITLE
feature: Expose OLCesiumOptions

### DIFF
--- a/src/olcs.ts
+++ b/src/olcs.ts
@@ -1,6 +1,8 @@
 import OLCesium from './olcs/OLCesium.js';
 export default OLCesium;
 
+export type {OLCesiumOptions} from './olcs/OLCesium.js';
+
 export {default as AbstractSynchronizer} from './olcs/AbstractSynchronizer.js';
 export {default as RasterSynchronizer} from './olcs/RasterSynchronizer.js';
 export {default as VectorSynchronizer} from './olcs/VectorSynchronizer.js';

--- a/src/olcs/OLCesium.ts
+++ b/src/olcs/OLCesium.ts
@@ -61,13 +61,13 @@ type SceneOptions = {
   msaaSamples?: number;
 }
 
-type OLCesiumOptions = {
+export type OLCesiumOptions = {
   map: Map,
   time?: () => JulianDate,
   target?: Element | string,
   createSynchronizers?: (map: Map, scene: Scene, dataSourceCollection: DataSourceCollection) => AbstractSynchronizer<ImageryLayer | VectorLayerCounterpart>[],
   stopOpenLayersEventsPropagation?: boolean,
-  sceneOptions?: SceneOptions
+  sceneOptions?: Omit<SceneOptions, 'canvas'|'scene3DOnly'>
 }
 
 // FIXME: remove this when all the synchronizers are migrated to typescript.


### PR DESCRIPTION
Downstream projects find it helpful to be able to reuse the type definition of the constructor options for the main OLCesium object.

I also corrected the type of the `sceneOptions` option: The `canvas` and `scene3DOnly` options are set internally and so should not be passed as part of the `sceneOptions`. Previously `canvas` strictly had to be passed as it is defined as a non-optional member of `SceneOptions`.