### PR TITLE
feat(olcs): Support skipping vector synchronization.

### DIFF
--- a/src/olcs/FeatureConverter.ts
+++ b/src/olcs/FeatureConverter.ts
@@ -1165,6 +1165,10 @@ export default class FeatureConverter {
       if (!feature) {
         continue;
       }
+      const skip = feature.get('olcs_skip')
+      if (skip) {
+        continue;
+      }
       const layerStyle: StyleFunction | undefined = olLayer.getStyleFunction();
       const styles = this.computePlainStyle(olLayer, feature, layerStyle,
           resolution);
@@ -1203,6 +1207,11 @@ export default class FeatureConverter {
    * @api
    */
   convert(layer: VectorLayer<BackwardCompatibleFeature>, view: View, feature: Feature, context: OlFeatureToCesiumContext): PrimitiveCollection {
+    const skip = feature.get('olcs_skip');
+    if (skip) {
+      return null;
+    }
+
     const proj = view.getProjection();
     const resolution = view.getResolution();
 

--- a/src/olcs/FeatureConverter.ts
+++ b/src/olcs/FeatureConverter.ts
@@ -1165,7 +1165,7 @@ export default class FeatureConverter {
       if (!feature) {
         continue;
       }
-      const skip = feature.get('olcs_skip')
+      const skip = feature.get('olcs_skip');
       if (skip) {
         continue;
       }

--- a/src/olcs/VectorSynchronizer.ts
+++ b/src/olcs/VectorSynchronizer.ts
@@ -159,7 +159,8 @@ export default class VectorSynchronizer extends olcsAbstractSynchronizer<VectorL
     }));
 
     olListenKeys.push(source.on('changefeature', (e: VectorSourceEvent) => {
-      const feature = e.feature;
+      const feature = e.feature
+      console.assert(feature);
       const skip = feature.get('olcs_skip');
       if (skip) {
         return;

--- a/src/olcs/VectorSynchronizer.ts
+++ b/src/olcs/VectorSynchronizer.ts
@@ -126,7 +126,7 @@ export default class VectorSynchronizer extends olcsAbstractSynchronizer<VectorL
     };
 
     const onRemoveFeature = (feature: Feature) => {
-      const skip = feature.get('olcs_skip')
+      const skip = feature.get('olcs_skip');
       if (skip) {
         return;
       }
@@ -160,7 +160,7 @@ export default class VectorSynchronizer extends olcsAbstractSynchronizer<VectorL
 
     olListenKeys.push(source.on('changefeature', (e: VectorSourceEvent) => {
       const feature = e.feature;
-      const skip = feature.get('olcs_skip')
+      const skip = feature.get('olcs_skip');
       if (skip) {
         return;
       }

--- a/src/olcs/VectorSynchronizer.ts
+++ b/src/olcs/VectorSynchronizer.ts
@@ -96,6 +96,11 @@ export default class VectorSynchronizer extends olcsAbstractSynchronizer<VectorL
     }
 
     console.assert(source instanceof olSourceVector);
+
+    const skip = source.get('olcs_skip');
+    if (skip) {
+      return null;
+    }
     console.assert(this.view);
 
     const view = this.view;
@@ -121,6 +126,10 @@ export default class VectorSynchronizer extends olcsAbstractSynchronizer<VectorL
     };
 
     const onRemoveFeature = (feature: Feature) => {
+      const skip = feature.get('olcs_skip')
+      if (skip) {
+        return;
+      }
       const id = getUid(feature);
       const context: OlFeatureToCesiumContext = counterpart.context;
       const bbs = context.featureToCesiumMap[id];
@@ -151,7 +160,10 @@ export default class VectorSynchronizer extends olcsAbstractSynchronizer<VectorL
 
     olListenKeys.push(source.on('changefeature', (e: VectorSourceEvent) => {
       const feature = e.feature;
-      console.assert(feature);
+      const skip = feature.get('olcs_skip')
+      if (skip) {
+        return;
+      }
       onRemoveFeature(feature);
       onAddFeature(feature);
     }));

--- a/src/olcs/VectorSynchronizer.ts
+++ b/src/olcs/VectorSynchronizer.ts
@@ -159,7 +159,7 @@ export default class VectorSynchronizer extends olcsAbstractSynchronizer<VectorL
     }));
 
     olListenKeys.push(source.on('changefeature', (e: VectorSourceEvent) => {
-      const feature = e.feature
+      const feature = e.feature;
       console.assert(feature);
       const skip = feature.get('olcs_skip');
       if (skip) {


### PR DESCRIPTION
In practical application scenarios, it is necessary to skip the synchronization of vector layers, data sources and even features, therefore, like the tile layer support `olcs_skip` attribute to skip synchronization, expanding the support for skip synchronization logic for vector layers.