### PR TITLE
rotateAroundAxis Use nullish coalescing instead of defaultValue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "olcs",
-  "version": "2.22.1",
+  "version": "2.22.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "olcs",
-      "version": "2.22.1",
+      "version": "2.22.3",
       "license": "BSD-2-Clause",
       "devDependencies": {
         "@babel/parser": "7.27.5",

--- a/src/olcs/core.ts
+++ b/src/olcs/core.ts
@@ -132,11 +132,10 @@ export function createMatrixAtCoordinates(
 export function rotateAroundAxis(camera: Camera, angle: number, axis: Cartesian3, transform: Matrix4,
     opt_options?: RotateAroundAxisOption) {
   const clamp = Cesium.Math.clamp;
-  const defaultValue = Cesium.defaultValue;
 
   const options: RotateAroundAxisOption = opt_options;
-  const duration = defaultValue(options?.duration, 500); // ms
-  const easing = defaultValue(options?.easing, linearEasing);
+  const duration = options?.duration ?? 500; // ms
+  const easing = options?.easing ?? linearEasing;
   const callback = options?.callback;
 
   let lastProgress = 0;


### PR DESCRIPTION
Use nullish coalescing instead of defaultValue for using rotateAroundAxis with newer cesium versions. defaultValue is deprecated since 1.128 and removed since 1.134