### PR TITLE
Fix types exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,11 +44,11 @@
     },
     "./css/olcs.css": "./css/olcs.css",
     "./src/*.js": {
-      "types": "./lib/types/*.d.ts",
+      "types": "./lib/types/olcs/*.d.ts",
       "default": "./lib/olcs/*.js"
     },
     "./*.js": {
-      "types": "./lib/types/*.d.ts",
+      "types": "./lib/types/olcs/*.d.ts",
       "default": "./lib/olcs/*.js"
     }
   },


### PR DESCRIPTION
Unfortunately I had missed that the types paths are also incorrect, so my fix in #1308 was incomplete.