### PR TITLE
Do not include API docs in the npm package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Draft release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run prepare
+      - name: Create release zip
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          zip -r "olcs-${VERSION}.zip" package.json LICENSE README.md PROPERTIES.md css/ src/ lib/ apidoc/
+      - name: Draft GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          generate_release_notes: true
+          files: olcs-*.zip

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,4 +16,5 @@ Each month, a new release is published in accordance to https://github.com/openl
   - npm version minor # or patch
   - npm pack
   - npm publish # this will publish package olcs (ol-cesium package is obsolete and not updated anymore)
-  - git push --tags # this will trigger the deploy workflow to publish the website
+  - git push --tags # this will trigger the deploy workflow to publish the website and create a draft GitHub release
+  - Review and publish the draft release at https://github.com/openlayers/ol-cesium/releases

--- a/package.json
+++ b/package.json
@@ -35,9 +35,6 @@
     }
   },
   "types": "lib/types/olcs.d.ts",
-  "directories": {
-    "doc": "apidoc/"
-  },
   "homepage": "https://github.com/openlayers/ol-cesium/",
   "keywords": [
     "Cesium",
@@ -50,8 +47,7 @@
     "PROPERTIES.md",
     "css/",
     "src/",
-    "lib/",
-    "apidoc/"
+    "lib/"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
It's not considered common practice to include API docs in the npm package, so let's remove them.

Instead, we now draft a release upon tag creation, and future releases will contain a zip rather than a tar.gz (probably easier for most users), with the same contents as previous releases.