### PR TITLE
Fix:#1338 the issue where the camera bounding sphere constraint is not actually taking effect

### DIFF
--- a/src/olcs/contrib/Manager.ts
+++ b/src/olcs/contrib/Manager.ts
@@ -162,11 +162,12 @@ export default class Manager extends Observable {
    */
   protected limitCameraToBoundingSphere() {
     const scene = this.ol3d.getCesiumScene();
-    limitCameraToBoundingSphere(
+    const limiter = limitCameraToBoundingSphere(
       scene.camera,
       this.boundingSphere_,
       this.limitCameraToBoundingSphereRatio,
     );
+    limiter();
   }
 
   /**

--- a/src/olcs/contrib/Manager.ts
+++ b/src/olcs/contrib/Manager.ts
@@ -162,12 +162,14 @@ export default class Manager extends Observable {
    */
   protected limitCameraToBoundingSphere() {
     const scene = this.ol3d.getCesiumScene();
-    const limiter = limitCameraToBoundingSphere(
-      scene.camera,
-      this.boundingSphere_,
-      this.limitCameraToBoundingSphereRatio,
-    );
-    limiter();
+    if(this.boundingSphere_){
+      const limiter = limitCameraToBoundingSphere(
+        scene.camera,
+        this.boundingSphere_,
+        this.limitCameraToBoundingSphereRatio,
+      );
+      scene.postRender.addEventListener(limiter);
+    }
   }
 
   /**

--- a/src/olcs/contrib/Manager.ts
+++ b/src/olcs/contrib/Manager.ts
@@ -162,7 +162,7 @@ export default class Manager extends Observable {
    */
   protected limitCameraToBoundingSphere() {
     const scene = this.ol3d.getCesiumScene();
-    if(this.boundingSphere_){
+    if (this.boundingSphere_) {
       const limiter = limitCameraToBoundingSphere(
         scene.camera,
         this.boundingSphere_,


### PR DESCRIPTION
In core.ts, limitCameraToBoundingSphere() returns a closure that must be saved and executed by the caller to apply the constraint. However, the Manager method discards the returned value after calling it, meaning the camera is never actually constrained.

Fixes #1338.